### PR TITLE
added out-of-bounds memory access check

### DIFF
--- a/benchmarks/suites/polybench/cholesky/cholesky.cu
+++ b/benchmarks/suites/polybench/cholesky/cholesky.cu
@@ -17,9 +17,8 @@ __global__ void kernel0(pbsize_t n, idx_t j, real *A) {
 __global__ void kernel1(pbsize_t n, idx_t j, real *A) {
   idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
 
-  if (j < n && i > j)
-    if ((i * n + j) < (n * n) && (j * n + j) < (n * n))
-      A[i * n + j] /= A[j * n + j];
+  if (j < n && i > j && (i * n + j) < (n * n) && (j * n + j) < (n * n))
+    A[i * n + j] /= A[j * n + j];
 }
 
 

--- a/benchmarks/suites/polybench/cholesky/cholesky.cu
+++ b/benchmarks/suites/polybench/cholesky/cholesky.cu
@@ -3,7 +3,6 @@
 #include "cholesky-common.h"
 #include <rosetta.h>
 
-
 // https://dl.acm.org/doi/pdf/10.1145/3038228.3038237
 // https://people.ast.cam.ac.uk/~stg20/cuda/cholesky/
 
@@ -19,7 +18,8 @@ __global__ void kernel1(pbsize_t n, idx_t j, real *A) {
   idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (j < n && i > j)
-    A[i * n + j] /= A[j * n + j];
+    if ((i * n + j) < (n * n) && (j * n + j) < (n * n))
+      A[i * n + j] /= A[j * n + j];
 }
 
 

--- a/benchmarks/suites/polybench/cholesky/cholesky.cu
+++ b/benchmarks/suites/polybench/cholesky/cholesky.cu
@@ -17,7 +17,7 @@ __global__ void kernel0(pbsize_t n, idx_t j, real *A) {
 __global__ void kernel1(pbsize_t n, idx_t j, real *A) {
   idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
 
-  if (j < n && i > j && (i * n + j) < (n * n) && (j * n + j) < (n * n))
+  if (i < n && i > j)
     A[i * n + j] /= A[j * n + j];
 }
 


### PR DESCRIPTION
CUDA gdb indicates the out-of-bounds memory access:

```
$ cuda-gdb --args /.../rosetta/debugdir/benchmarks/suites.polybench.cholesky.cuda --xmlout=.../rosetta/debugdir/results/20230716_1325/suites.polybench.cholesky.cuda.xml '--timestamp=2023-07-16 18:25:59.330089+00:00'
$ ./bench-Debug.py
Thread 1 "suites.polybenc" received signal CUDA_EXCEPTION_14, Warp Illegal Address.
[Switching focus to CUDA kernel 0, grid 2, block (255,0,0), thread (0,0,0), device 0, sm 1, warp 8, lane 0]
0x00007fffc727b3f0 in kernel1<<<(256,1,1),(16,1,1)>>> (n=4000, j=0, A=0x7fffb6000000) at .../rosetta/benchmarks/suites/polybench/cholesky/cholesky.cu:21
21          A[i * n + j] /= A[j * n + j];
```

Adding the check is working for `extralarge` problem size.