### PR TITLE
Add HIP Polybench benchmarks except 3mm, durbin, and gramschmidt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv/
 release/
 results/
 html_report/
+cmake-build-debug/

--- a/benchmarks/suites/polybench/2mm/2mm.hip
+++ b/benchmarks/suites/polybench/2mm/2mm.hip
@@ -1,0 +1,115 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+
+
+__global__ void kernel_A_mul_B(pbsize_t ni, pbsize_t nj, pbsize_t nk, pbsize_t nl,
+                               real alpha, real beta,
+                               real *tmp,
+                               real *A,
+                               real *B, real *C, real *D) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (i < ni && j < nj) {
+    for (idx_t k = 0; k < nk; k++)
+      tmp[i * nj + j] += A[i * nk + k] * B[k * nj + j];
+    tmp[i * nj + j] *= alpha;
+  }
+}
+
+
+
+__global__ void kernel_D_plus_tmp_mul_C(pbsize_t ni, pbsize_t nj, pbsize_t nk, pbsize_t nl,
+                                        real alpha, real beta,
+                                        real *tmp,
+                                        real *A,
+                                        real *B, real *C, real *D) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t l = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (i < ni && l < nl) {
+    D[i * nj + l] *= beta;
+
+
+    for (idx_t j = 0; j < nj; j++)
+      D[i * nl + l] += tmp[i * nj + j] * C[j * nl + l];
+  }
+}
+
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+static void kernel(pbsize_t ni, pbsize_t nj, pbsize_t nk, pbsize_t nl,
+                   real alpha, real beta,
+                   real *tmp,
+                   real *A,
+                   real *B, real *C, real *D) {
+
+
+  unsigned threadsPerBlock = 256;
+  dim3 block{threadsPerBlock / 32, 32, 1};
+
+  {
+    dim3 grid{num_blocks(ni, block.x), num_blocks(nj, block.y), 1};
+    kernel_A_mul_B<<<block, grid>>>(ni, nj, nk, nl, alpha, beta, tmp, A, B, C, D);
+  }
+
+
+  {
+    dim3 grid{num_blocks(ni, block.x), num_blocks(nl, block.y), 1};
+    kernel_D_plus_tmp_mul_C<<<block, grid>>>(ni, nj, nk, nl, alpha, beta, tmp, A, B, C, D);
+  }
+}
+
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t ni = pbsize - pbsize / 3;  // 800
+  pbsize_t nj = pbsize - pbsize / 4;  // 900
+  pbsize_t nk = pbsize - pbsize / 12; // 1100
+  pbsize_t nl = pbsize;               // 1200
+
+  real alpha = 1.5;
+  real beta = 1.2;
+  auto A = state.allocate_array<real>({ni, nk}, /*fakedata*/ true, /*verify*/ false, "A");
+  auto B = state.allocate_array<real>({nk, nj}, /*fakedata*/ true, /*verify*/ false, "B");
+  auto C = state.allocate_array<real>({nj, nl}, /*fakedata*/ true, /*verify*/ false, "C");
+  auto D = state.allocate_array<real>({ni, nl}, /*fakedata*/ true, /*verify*/ true, "D");
+
+  real *dev_tmp = state.allocate_dev_hip<real>(ni * nj);
+  real *dev_A = state.allocate_dev_hip<real>(ni * nk);
+  real *dev_B = state.allocate_dev_hip<real>(nk * nj);
+  real *dev_C = state.allocate_dev_hip<real>(nj * nl);
+  real *dev_D = state.allocate_dev_hip<real>(ni * nl);
+
+  for (auto &&_ : state) {
+    hipMemset(dev_tmp, '\0', ni * nj * sizeof(real));
+    hipMemcpy(dev_A, A.data(), ni * nk * sizeof(real), hipMemcpyHostToDevice);
+    hipMemcpy(dev_B, B.data(), nk * nj * sizeof(real), hipMemcpyHostToDevice);
+    hipMemcpy(dev_C, C.data(), nj * nl * sizeof(real), hipMemcpyHostToDevice);
+    hipMemcpy(dev_D, D.data(), ni * nl * sizeof(real), hipMemcpyHostToDevice);
+
+
+    kernel(ni, nj, nk, nl, alpha, beta, dev_tmp, dev_A, dev_B, dev_C, dev_D);
+
+
+    hipMemcpy(D.data(), dev_D, ni * nl * sizeof(real), hipMemcpyDeviceToHost);
+
+    hipDeviceSynchronize();
+  }
+
+  state.free_dev_hip(dev_tmp);
+  state.free_dev_hip(dev_A);
+  state.free_dev_hip(dev_B);
+  state.free_dev_hip(dev_C);
+  state.free_dev_hip(dev_D);
+}

--- a/benchmarks/suites/polybench/adi/adi.hip
+++ b/benchmarks/suites/polybench/adi/adi.hip
@@ -1,0 +1,129 @@
+// BUILD: add_benchmark(ppm=hip)
+#include "rosetta.h"
+
+
+
+__global__ void kernel_column_sweep(pbsize_t tsteps,
+                                    pbsize_t n,
+                                    real *u,
+                                    real *v,
+                                    real *p,
+                                    real *q, real a, real b, real c, real d, real e, real f) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x + 1;
+
+
+  if (i < n - 1) {
+    v[0 * n + i] = 1;
+    p[i * n + 0] = 0;
+    q[i * n + 0] = v[0 * n + i];
+    for (idx_t j = 1; j < n - 1; j++) {
+      p[i * n + j] = -c / (a * p[i * n + j - 1] + b);
+      q[i * n + j] = (-d * u[j * n + i - 1] + (1 + 2 * d) * u[j * n + i] - f * u[j * n + i + 1] - a * q[i * n + j - 1]) / (a * p[i * n + j - 1] + b);
+    }
+
+    v[(n - 1) * n + i] = 1;
+    for (idx_t j = n - 2; j >= 1; j--)
+      v[j * n + i] = p[i * n + j] * v[(j + 1) * n + i] + q[i * n + j];
+  }
+}
+
+
+__global__ void kernel_row_sweep(pbsize_t tsteps, pbsize_t n, real *u, real *v, real *p, real *q, real a, real b, real c, real d, real e, real f) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x + 1;
+
+  if (i < n - 1) {
+    u[i * n + 0] = 1;
+    p[i + n + 0] = 0;
+    q[i * n + 0] = u[i * n + 0];
+    for (idx_t j = 1; j < n - 1; j++) {
+      p[i * n + j] = -f / (d * p[i * n + j - 1] + e);
+      q[i * n + j] = (-a * v[(i - 1) * n + j] + (1 + 2 * a) * v[i * n + j] - c * v[(i + 1) * n + j] - d * q[i * n + j - 1]) / (d * p[i * n + j - 1] + e);
+    }
+    u[i * n + n - 1] = 1;
+    for (idx_t j = n - 2; j >= 1; j--)
+      u[i * n + j] = p[i * n + j] * u[i * n + j + 1] + q[i * n + j];
+  }
+}
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+static void kernel(
+    pbsize_t tsteps,
+    pbsize_t n,
+    real *u,
+    real *v,
+    real *p,
+    real *q) {
+  unsigned threadsPerBlock = 256;
+
+  real DX = 1 / (real)n;
+  real DY = 1 / (real)n;
+  real DT = 1 / (real)tsteps;
+  real B1 = 2;
+  real B2 = 1;
+  real mul1 = B1 * DT / (DX * DX);
+  real mul2 = B2 * DT / (DY * DY);
+
+  real a = -mul1 / 2;
+  real b = 1 + mul1;
+  real c = a;
+  real d = -mul2 / 2;
+  real e = 1 + mul2;
+  real f = d;
+
+
+
+  for (idx_t t = 1; t <= tsteps; t++) {
+    // Column Sweep
+    kernel_column_sweep<<<threadsPerBlock, num_blocks(n - 2, threadsPerBlock)>>>(tsteps, n, u, v, p, q, a, b, c, d, e, f);
+
+    // Row Sweep
+    kernel_row_sweep<<<threadsPerBlock, num_blocks(n - 2, threadsPerBlock)>>>(tsteps, n, u, v, p, q, a, b, c, d, e, f);
+  }
+}
+
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t tsteps = pbsize / 2; // 500
+  pbsize_t n = pbsize;          // 1000
+
+
+
+  auto u = state.allocate_array<double>({n, n}, /*fakedata*/ true, /*verify*/ true, "u");
+  // auto v = state.allocate_array<double>({n, n}, /*fakedata*/ false, /*verify*/ false,"v");
+  // auto p = state.allocate_array<double>({n, n}, /*fakedata*/ false, /*verify*/ false, "p");
+  // auto q = state.allocate_array<double>({n, n}, /*fakedata*/ false, /*verify*/ false, "q");
+
+
+  real *dev_u = state.allocate_dev_hip<real>(n * n);
+  real *dev_v = state.allocate_dev_hip<real>(n * n);
+  real *dev_p = state.allocate_dev_hip<real>(n * n);
+  real *dev_q = state.allocate_dev_hip<real>(n * n);
+
+  for (auto &&_ : state) {
+    hipMemcpy(dev_u, u.data(), n * n * sizeof(real), hipMemcpyHostToDevice);
+    hipMemset(dev_v, '\0', n * n * sizeof(real));
+    hipMemset(dev_p, '\0', n * n * sizeof(real));
+    hipMemset(dev_q, '\0', n * n * sizeof(real));
+
+
+
+    kernel(tsteps, n, dev_u, dev_v, dev_p, dev_q);
+
+
+    hipMemcpy(u.data(), dev_u, n * n * sizeof(real), hipMemcpyDeviceToHost);
+
+    hipDeviceSynchronize();
+  }
+
+  state.free_dev_hip(dev_u);
+  state.free_dev_hip(dev_v);
+  state.free_dev_hip(dev_p);
+  state.free_dev_hip(dev_q);
+}

--- a/benchmarks/suites/polybench/atax/atax.hip
+++ b/benchmarks/suites/polybench/atax/atax.hip
@@ -1,0 +1,72 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+
+
+__global__ void kernel3(pbsize_t m, pbsize_t n, real *A, real *x, real *y, real *tmp) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (i < m) {
+    for (idx_t j = 0; j < n; j++)
+      tmp[i] += A[i * n + j] * x[j];
+  }
+}
+
+
+__global__ void kernel4(pbsize_t m, pbsize_t n, real *A, real *x, real *y, real *tmp) {
+  idx_t j = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (j < n) {
+    for (idx_t i = 0; i < m; i++)
+      y[j] += A[i * n + j] * tmp[i];
+  }
+}
+
+
+
+static int num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+void run(State &state, int pbsize) {
+  // n is 5%-20% larger than m
+  pbsize_t n = pbsize;
+  pbsize_t m = pbsize - pbsize / 10;
+
+
+  auto A = state.allocate_array<real>({m, n}, /*fakedata*/ true, /*verify*/ false, "A");
+  auto x = state.allocate_array<real>({n}, /*fakedata*/ true, /*verify*/ false, "x");
+  auto y = state.allocate_array<real>({n}, /*fakedata*/ false, /*verify*/ true, "y");
+
+
+  real *dev_A = state.allocate_dev_hip<real>(n * m);
+  real *dev_x = state.allocate_dev_hip<real>(n);
+  real *dev_y = state.allocate_dev_hip<real>(n);
+  real *dev_tmp = state.allocate_dev_hip<real>(m);
+
+
+
+  for (auto &&_ : state) {
+    hipMemcpy(dev_A, A.data(), n * m * sizeof(real), hipMemcpyHostToDevice);
+    hipMemcpy(dev_x, A.data(), n * sizeof(real), hipMemcpyHostToDevice);
+    hipMemset(dev_y, '\0', n * sizeof(real));
+    hipMemset(dev_tmp, '\0', m * sizeof(real));
+
+
+    const int threadsPerBlock = 256;
+    kernel3<<<threadsPerBlock, num_blocks(m, threadsPerBlock)>>>(m, n, dev_A, dev_x, dev_y, dev_tmp);
+    kernel4<<<threadsPerBlock, num_blocks(n, threadsPerBlock)>>>(m, n, dev_A, dev_x, dev_y, dev_tmp);
+
+    hipMemcpy(y.data(), dev_y, n * sizeof(real), hipMemcpyDeviceToHost);
+
+    hipDeviceSynchronize();
+  }
+
+
+  state.free_dev_hip(dev_A);
+  state.free_dev_hip(dev_x);
+  state.free_dev_hip(dev_y);
+  state.free_dev_hip(dev_tmp);
+}

--- a/benchmarks/suites/polybench/bicg/bicg.hip
+++ b/benchmarks/suites/polybench/bicg/bicg.hip
@@ -1,0 +1,79 @@
+// BUILD: add_benchmark(ppm=hip)
+#include "rosetta.h"
+
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+__global__ void kernel_q(pbsize_t m, pbsize_t n, real *A, real s[], real q[], real p[], real r[]) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (i < n) {
+    q[i] = 0;
+    for (idx_t j = 0; j < m; j++)
+      q[i] += A[i * m + j] * p[j];
+  }
+}
+
+
+__global__ void kernel_s(pbsize_t m, pbsize_t n, real *A, real s[], real q[], real p[], real r[]) {
+  idx_t j = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (j < m) {
+    s[j] = 0;
+    for (idx_t i = 0; i < n; i++)
+      s[j] += r[i] * A[i * m + j];
+  }
+}
+
+
+
+static void kernel(pbsize_t m, pbsize_t n, real *A, real s[], real q[], real p[], real r[]) {
+  const unsigned threadsPerBlock = 256;
+  kernel_q<<<threadsPerBlock, num_blocks(n, threadsPerBlock)>>>(m, n, A, s, q, p, r);
+  kernel_s<<<threadsPerBlock, num_blocks(m, threadsPerBlock)>>>(m, n, A, s, q, p, r);
+}
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t m = pbsize - 19 * pbsize / 21; // 1900
+  pbsize_t n = pbsize;                    // 2100
+
+  auto A = state.allocate_array<real>({n, m}, /*fakedata*/ true, /*verify*/ false, "A");
+  auto s = state.allocate_array<real>({m}, /*fakedata*/ false, /*verify*/ true, "s");
+  auto q = state.allocate_array<real>({n}, /*fakedata*/ false, /*verify*/ true, "q");
+  auto p = state.allocate_array<real>({m}, /*fakedata*/ true, /*verify*/ false, "p");
+  auto r = state.allocate_array<real>({n}, /*fakedata*/ true, /*verify*/ false, "r");
+
+  real *dev_A = state.allocate_dev_hip<real>(n * m);
+  real *dev_s = state.allocate_dev_hip<real>(m);
+  real *dev_q = state.allocate_dev_hip<real>(n);
+  real *dev_p = state.allocate_dev_hip<real>(m);
+  real *dev_r = state.allocate_dev_hip<real>(n);
+
+
+  for (auto &&_ : state) {
+    hipMemcpy(dev_A, A.data(), n * m * sizeof(real), hipMemcpyHostToDevice);
+    //    cudaMemset(dev_s, '\0', m * sizeof(real));
+    //            cudaMemset(dev_q, '\0', n * sizeof(real));
+    hipMemcpy(dev_p, p.data(), m * sizeof(real), hipMemcpyHostToDevice);
+    hipMemcpy(dev_r, r.data(), n * sizeof(real), hipMemcpyHostToDevice);
+
+    kernel(m, n, dev_A, dev_s, dev_q, dev_p, dev_r);
+
+    hipMemcpy(s.data(), dev_s, m * sizeof(real), hipMemcpyDeviceToHost);
+    hipMemcpy(q.data(), dev_q, n * sizeof(real), hipMemcpyDeviceToHost);
+
+    hipDeviceSynchronize();
+  }
+
+  state.free_dev_hip(dev_A);
+  state.free_dev_hip(dev_s);
+  state.free_dev_hip(dev_q);
+  state.free_dev_hip(dev_p);
+  state.free_dev_hip(dev_r);
+}

--- a/benchmarks/suites/polybench/cholesky/cholesky.hip
+++ b/benchmarks/suites/polybench/cholesky/cholesky.hip
@@ -1,0 +1,83 @@
+// BUILD: add_benchmark(ppm=hip,sources=[__file__, "cholesky-common.cxx"])
+
+#include "cholesky-common.h"
+#include <rosetta.h>
+
+// https://dl.acm.org/doi/pdf/10.1145/3038228.3038237
+// https://people.ast.cam.ac.uk/~stg20/cuda/cholesky/
+
+
+
+__global__ void kernel0(pbsize_t n, idx_t j, real *A) {
+  A[j * n + j] = std::sqrt(A[j * n + j]);
+}
+
+
+
+__global__ void kernel1(pbsize_t n, idx_t j, real *A) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (i < n && i > j)
+    A[i * n + j] /= A[j * n + j];
+}
+
+
+__global__ void kernel2(pbsize_t n, idx_t j, real *A) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t k = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (j < n && j < i && i < n && j < k && k <= i)
+    A[i * n + k] -= A[i * n + j] * A[k * n + j];
+}
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+static void kernel_polly(pbsize_t n, real *dev_A) {
+  const unsigned int threadsPerBlock = 256;
+
+
+  for (idx_t j = 0; j < n; j++) {
+    kernel0<<<1, 1>>>(n, j, dev_A);
+
+    kernel1<<<threadsPerBlock, num_blocks(n, threadsPerBlock)>>>(n, j, dev_A);
+
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(n, block.x), num_blocks(n, block.y), 1};
+    kernel2<<<block, grid>>>(n, j, dev_A);
+  }
+}
+
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t n = pbsize; // 2000
+
+
+  auto A = state.allocate_array<real>({n, n}, /*fakedata*/ true, /*verify*/ true, "A");
+  real *dev_A = state.allocate_dev_hip<real>(n * n);
+
+
+  for (auto &&_ : state.manual()) {
+    ensure_posdefinite(n, A);
+
+    {
+      auto &&scope = _.scope();
+
+      hipMemcpy(dev_A, A.data(), n * n * sizeof(real), hipMemcpyHostToDevice);
+
+      kernel_polly(n, dev_A);
+
+      hipMemcpy(A.data(), dev_A, n * n * sizeof(real), hipMemcpyDeviceToHost);
+    }
+
+    hipDeviceSynchronize();
+  }
+
+  state.free_dev_hip(dev_A);
+}

--- a/benchmarks/suites/polybench/correlation/correlation.hip
+++ b/benchmarks/suites/polybench/correlation/correlation.hip
@@ -1,0 +1,181 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+__global__ void kernel_mean(pbsize_t m, pbsize_t n,
+                            real *data,
+                            real *corr,
+                            real mean[],
+                            real stddev[]) {
+  idx_t j = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (j < m) {
+    mean[j] = 0.0;
+    for (idx_t i = 0; i < n; i++)
+      mean[j] += data[i * m + j];
+    mean[j] /= n;
+  }
+}
+
+
+__global__ void kernel_stddev(pbsize_t m, pbsize_t n,
+                              real *data,
+                              real *corr,
+                              real mean[],
+                              real stddev[]) {
+  idx_t j = blockDim.x * blockIdx.x + threadIdx.x;
+  const real eps = 0.1;
+
+  if (j < m) {
+    stddev[j] = 0.0;
+    for (idx_t i = 0; i < n; i++)
+      stddev[j] += (data[i * m + j] - mean[j]) * (data[i * m + j] - mean[j]);
+    stddev[j] /= n;
+    stddev[j] = sqrt(stddev[j]);
+    /* The following in an inelegant but usual way to handle
+       near-zero std. dev. values, which below would cause a zero-
+       divide. */
+    if (stddev[j] <= eps)
+      stddev[j] = 1.0;
+  }
+}
+
+
+
+__global__ void kernel_reduce(pbsize_t m, pbsize_t n,
+                              real *data,
+                              real *corr,
+                              real mean[],
+                              real stddev[]) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (i < n && j < m) {
+    data[i * m + j] -= mean[j];
+    data[i * m + j] /= std::sqrt((real)n) * stddev[j];
+  }
+}
+
+
+
+__global__ void kernel_diag(pbsize_t m, pbsize_t n,
+                            real *data,
+                            real *corr,
+                            real mean[],
+                            real stddev[]) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (i < m) {
+    corr[i * m + i] = 1.0;
+  }
+}
+
+
+
+__global__ void kernel_corr(pbsize_t m, pbsize_t n,
+                            real *data,
+                            real *corr,
+                            real mean[],
+                            real stddev[]) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y + i + 1;
+
+
+  //  for (idx_t i = 0; i < m - 1; i++) {
+  //       for (idx_t j = i + 1; j < m; j++) {
+
+  if (i < m - 1 && j < m) {
+    corr[i * m + j] = 0.0;
+    for (int k = 0; k < n; k++)
+      corr[i * m + j] += (data[k * m + i] * data[k * m + j]);
+    corr[j * m + i] = corr[i * m + j];
+  }
+}
+
+
+__global__ void kernel_tail(pbsize_t m, pbsize_t n,
+                            real *data,
+                            real *corr,
+                            real mean[],
+                            real stddev[]) {
+  corr[(m - 1) * m + m - 1] = 1.0;
+}
+
+
+
+static void kernel(pbsize_t m, pbsize_t n,
+                   real *data,
+                   real *corr,
+                   real mean[],
+                   real stddev[]) {
+  const unsigned threadsPerBlock = 256;
+
+  kernel_mean<<<threadsPerBlock, num_blocks(m, threadsPerBlock)>>>(m, n, data, corr, mean, stddev);
+  kernel_stddev<<<threadsPerBlock, num_blocks(m, threadsPerBlock)>>>(m, n, data, corr, mean, stddev);
+
+
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(n, block.x), num_blocks(m, block.y), 1};
+    kernel_reduce<<<block, grid>>>(m, n, data, corr, mean, stddev);
+  }
+
+
+
+  kernel_diag<<<threadsPerBlock, num_blocks(m, threadsPerBlock)>>>(m, n, data, corr, mean, stddev);
+
+
+
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(m - 1, block.x), num_blocks(m - 1, block.y), 1};
+    kernel_corr<<<block, grid>>>(m, n, data, corr, mean, stddev);
+  }
+
+
+  kernel_tail<<<1, 1>>>(m, n, data, corr, mean, stddev);
+}
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t n = pbsize;
+  pbsize_t m = pbsize - pbsize / 6;
+
+
+  auto data = state.allocate_array<real>({n, m}, /*fakedata*/ true, /*verify*/ false, "data");
+  auto mean = state.allocate_array<real>({m}, /*fakedata*/ false, /*verify*/ true, "mean");
+  auto stddev = state.allocate_array<real>({m}, /*fakedata*/ false, /*verify*/ true, "stddev");
+  auto corr = state.allocate_array<real>({m, m}, /*fakedata*/ false, /*verify*/ true, "corr");
+
+
+  real *dev_data = state.allocate_dev_hip<real>(n * m);
+  real *dev_corr = state.allocate_dev_hip<real>(m * m);
+  real *dev_mean = state.allocate_dev_hip<real>(m);
+  real *dev_stddev = state.allocate_dev_hip<real>(m);
+
+  for (auto &&_ : state) {
+    hipMemcpy(dev_data, data.data(), n * m * sizeof(real), hipMemcpyHostToDevice);
+    hipMemset(dev_corr, '\0', m * m * sizeof(real));
+    //      cudaMemset(dev_mean, '\0', m  * sizeof(real));
+
+    kernel(m, n, dev_data, dev_corr, dev_mean, dev_stddev);
+
+    hipMemcpy(corr.data(), dev_corr, m * m * sizeof(real), hipMemcpyDeviceToHost);
+    hipMemcpy(mean.data(), dev_mean, m * sizeof(real), hipMemcpyDeviceToHost);
+    hipMemcpy(stddev.data(), dev_stddev, m * sizeof(real), hipMemcpyDeviceToHost);
+
+    hipDeviceSynchronize();
+  }
+
+  state.free_dev_hip(dev_data);
+  state.free_dev_hip(dev_corr);
+  state.free_dev_hip(dev_mean);
+  state.free_dev_hip(dev_stddev);
+}

--- a/benchmarks/suites/polybench/covariance/covariance.hip
+++ b/benchmarks/suites/polybench/covariance/covariance.hip
@@ -1,0 +1,111 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include "rosetta.h"
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+__global__ void kernel_mean(pbsize_t m, pbsize_t n,
+                            real data[],
+                            real cov[],
+                            real mean[]) {
+  idx_t j = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (j < m) {
+    mean[j] = 0.0;
+    for (idx_t i = 0; i < n; i++)
+      mean[j] += data[i * m + j];
+    mean[j] /= n;
+  }
+}
+
+
+__global__ void kernel_reduce(pbsize_t m, pbsize_t n,
+                              real data[],
+                              real cov[],
+                              real mean[]) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (i < n && j < m) {
+    data[i * m + j] -= mean[j];
+  }
+}
+
+
+
+__global__ void kernel_cov(pbsize_t m, pbsize_t n,
+                           real data[],
+                           real cov[],
+                           real mean[]) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y + i;
+
+
+
+  if (i < m && j < m) {
+    cov[i * m + j] = 0.0;
+    for (idx_t k = 0; k < n; k++)
+      cov[i * m + j] += data[k * m + i] * data[k * m + j];
+    cov[i * m + j] /= (n - 1.0);
+    cov[j * m + i] = cov[i * m + j];
+  }
+}
+
+
+static void kernel(pbsize_t m, pbsize_t n,
+                   real data[],
+                   real cov[],
+                   real mean[]) {
+  const unsigned threadsPerBlock = 256;
+
+  kernel_mean<<<threadsPerBlock, num_blocks(m, threadsPerBlock)>>>(m, n, data, cov, mean);
+
+
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(n, block.x), num_blocks(m, block.y), 1};
+    kernel_reduce<<<block, grid>>>(m, n, data, cov, mean);
+  }
+
+
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(m - 1, block.x), num_blocks(m - 1, block.y), 1};
+    kernel_cov<<<block, grid>>>(m, n, data, cov, mean);
+  }
+}
+
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t n = pbsize;
+  pbsize_t m = pbsize - pbsize / 8;
+
+  auto data = state.allocate_array<real>({n, m}, /*fakedata*/ true, /*verify*/ false, "data");
+  auto mean = state.allocate_array<real>({m}, /*fakedata*/ false, /*verify*/ true, "mean");
+  auto cov = state.allocate_array<real>({m, m}, /*fakedata*/ false, /*verify*/ true, "cov");
+
+  real *dev_data = state.allocate_dev_hip<real>(n * m);
+  real *dev_mean = state.allocate_dev_hip<real>(m);
+  real *dev_cov = state.allocate_dev_hip<real>(m * m);
+
+  for (auto &&_ : state) {
+    hipMemcpy(dev_data, data.data(), n * m * sizeof(real), hipMemcpyHostToDevice);
+
+    kernel(m, n, dev_data, dev_cov, dev_mean);
+
+    hipMemcpy(mean.data(), dev_mean, m * sizeof(real), hipMemcpyDeviceToHost);
+    hipMemcpy(cov.data(), dev_cov, m * m * sizeof(real), hipMemcpyDeviceToHost);
+
+    hipDeviceSynchronize();
+  }
+
+  state.free_dev_hip(dev_data);
+  state.free_dev_hip(dev_mean);
+  state.free_dev_hip(dev_cov);
+}

--- a/benchmarks/suites/polybench/deriche/deriche.hip
+++ b/benchmarks/suites/polybench/deriche/deriche.hip
@@ -1,0 +1,210 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include "rosetta.h"
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+__global__ void kernel_y1_rowsweep(pbsize_t w, pbsize_t h,
+                                   real alpha,
+                                   real *imgIn,
+                                   real *imgOut,
+                                   real *y1,
+                                   real *y2,
+                                   real a1,
+                                   real a2,
+                                   real b1,
+                                   real b2) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (i < w) {
+    real ym1 = 0;
+    real ym2 = 0;
+    real xm1 = 0;
+    for (idx_t j = 0; j < h; j++) {
+      y1[i * h + j] = a1 * imgIn[i * h + j] + a2 * xm1 + b1 * ym1 + b2 * ym2;
+      xm1 = imgIn[i * h + j];
+      ym2 = ym1;
+      ym1 = y1[i * h + j];
+    }
+  }
+}
+
+__global__ void kernel_y2_rowsweep(pbsize_t w, pbsize_t h,
+                                   real alpha,
+                                   real *imgIn,
+                                   real *imgOut,
+                                   real *y1,
+                                   real *y2,
+                                   real a3,
+                                   real a4,
+                                   real b1,
+                                   real b2) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (i < w) {
+    real yp1 = 0;
+    real yp2 = 0;
+    real xp1 = 0;
+    real xp2 = 0;
+    for (idx_t j = h - 1; j >= 0; j--) {
+      y2[i * h + j] = a3 * xp1 + a4 * xp2 + b1 * yp1 + b2 * yp2;
+      xp2 = xp1;
+      xp1 = imgIn[i * h + j];
+      yp2 = yp1;
+      yp1 = y2[i * h + j];
+    }
+  }
+}
+
+
+__global__ void kernel_out(pbsize_t w, pbsize_t h,
+                           real alpha,
+                           real *imgIn,
+                           real *imgOut,
+                           real *y1,
+                           real *y2, real c) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+
+  if (i < w && j < h) {
+    imgOut[i * h + j] = c * (y1[i * h + j] + y2[i * h + j]);
+  }
+}
+
+
+__global__ void kernel_y1_colsweep(pbsize_t w, pbsize_t h,
+                                   real alpha,
+                                   real *imgIn,
+                                   real *imgOut,
+                                   real *y1,
+                                   real *y2,
+                                   real a5,
+                                   real a6,
+                                   real b1,
+                                   real b2) {
+  idx_t j = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (j < h) {
+    real tm1 = 0;
+    real ym1 = 0;
+    real ym2 = 0;
+    for (idx_t i = 0; i < w; i++) {
+      y1[i * h + j] = a5 * imgOut[i * h + j] + a6 * tm1 + b1 * ym1 + b2 * ym2;
+      tm1 = imgOut[i * h + j];
+      ym2 = ym1;
+      ym1 = y1[i * h + j];
+    }
+  }
+}
+
+
+__global__ void kernel_y2_colsweep(pbsize_t w, pbsize_t h,
+                                   real alpha,
+                                   real *imgIn,
+                                   real *imgOut,
+                                   real *y1,
+                                   real *y2,
+                                   real a7,
+                                   real a8,
+                                   real b1,
+                                   real b2) {
+  idx_t j = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (j < h) {
+    real tp1 = 0;
+    real tp2 = 0;
+    real yp1 = 0;
+    real yp2 = 0;
+    for (idx_t i = w - 1; i >= 0; i--) {
+      y2[i * h + j] = a7 * tp1 + a8 * tp2 + b1 * yp1 + b2 * yp2;
+      tp2 = tp1;
+      tp1 = imgOut[i * h + j];
+      yp2 = yp1;
+      yp1 = y2[i * h + j];
+    }
+  }
+}
+
+
+
+static void kernel(pbsize_t w, pbsize_t h,
+                   real alpha,
+                   real *imgIn,
+                   real *imgOut,
+                   real *y1,
+                   real *y2) {
+  real k = (1 - std::exp(-alpha)) * (1 - std::exp(-alpha)) / (1 + 2 * alpha * std::exp(-alpha) - std::exp(2 * alpha));
+  real a1 = k;
+  real a5 = k;
+  real a6 = k * std::exp(-alpha) * (alpha - 1);
+  real a2 = a6;
+  real a7 = k * std::exp(-alpha) * (alpha + 1);
+  real a3 = a7;
+  real a8 = -k * std::exp(-2 * alpha);
+  real a4 = a8;
+  real b1 = std::pow(2, -alpha);
+  real b2 = -std::exp(-2 * alpha);
+  real c1 = 1, c2 = 1;
+
+
+  const unsigned threadsPerBlock = 256;
+
+  kernel_y1_rowsweep<<<threadsPerBlock, num_blocks(w, threadsPerBlock)>>>(w, h, alpha, imgIn, imgOut, y1, y2, a1, a2, b1, b2);
+  kernel_y2_rowsweep<<<threadsPerBlock, num_blocks(w, threadsPerBlock)>>>(w, h, alpha, imgIn, imgOut, y1, y2, a3, a4, b1, b2);
+
+
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(w, block.x), num_blocks(h, block.y), 1};
+    kernel_out<<<block, grid>>>(w, h, alpha, imgIn, imgOut, y1, y2, c1);
+  }
+
+  kernel_y1_colsweep<<<threadsPerBlock, num_blocks(h, threadsPerBlock)>>>(w, h, alpha, imgIn, imgOut, y1, y2, a5, a6, b1, b2);
+  kernel_y2_colsweep<<<threadsPerBlock, num_blocks(h, threadsPerBlock)>>>(w, h, alpha, imgIn, imgOut, y1, y2, a7, a8, b1, b2);
+
+
+
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(w, block.x), num_blocks(h, block.y), 1};
+    kernel_out<<<block, grid>>>(w, h, alpha, imgIn, imgOut, y1, y2, c2);
+  }
+}
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t w = pbsize;                        // 4096
+  pbsize_t h = pbsize / 2 + 7 * pbsize / 256; // 2160
+
+  real alpha = 0.25;
+
+  auto imgIn = state.allocate_array<real>({w, h}, /*fakedata*/ true, /*verify*/ false, "imgIn");
+  auto imgOut = state.allocate_array<real>({w, h}, /*fakedata*/ false, /*verify*/ true, "imgOut");
+
+
+  real *dev_imgIn = state.allocate_dev_hip<real>(w * h);
+  real *dev_imgOut = state.allocate_dev_hip<real>(w * h);
+  real *dev_y1 = state.allocate_dev_hip<real>(w * h);
+  real *dev_y2 = state.allocate_dev_hip<real>(w * h);
+
+  for (auto &&_ : state) {
+    hipMemcpy(dev_imgIn, imgIn.data(), w * h * sizeof(real), hipMemcpyHostToDevice);
+
+    kernel(w, h, alpha, dev_imgIn, dev_imgOut, dev_y1, dev_y2);
+
+    hipMemcpy(imgOut.data(), dev_imgOut, w * h * sizeof(real), hipMemcpyDeviceToHost);
+
+    hipDeviceSynchronize();
+  }
+
+  state.free_dev_hip(dev_imgIn);
+  state.free_dev_hip(dev_imgOut);
+  state.free_dev_hip(dev_y1);
+  state.free_dev_hip(dev_y2);
+}

--- a/benchmarks/suites/polybench/doitgen/doitgen.hip
+++ b/benchmarks/suites/polybench/doitgen/doitgen.hip
@@ -1,0 +1,68 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include "rosetta.h"
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+__global__ void kernel_sum(pbsize_t nr, pbsize_t nq, pbsize_t np,
+                           real *A,
+                           real *C4, real *sum) {
+  idx_t r = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t q = blockDim.y * blockIdx.y + threadIdx.y;
+  idx_t p = blockDim.z * blockIdx.z + threadIdx.z;
+
+
+  if (r < nr && q < nq && p < np) {
+    sum[(r * nq + q) * np + p] = 0;
+    for (idx_t s = 0; s < np; s++)
+      sum[(r * nq + q) * np + p] += A[(r * nq + q) * np + s] * C4[s * np + p];
+  }
+}
+
+
+
+static void kernel(pbsize_t nr, pbsize_t nq, pbsize_t np,
+                   real *A,
+                   real *C4, real *sum) {
+  const unsigned threadsPerBlock = 256;
+
+  dim3 block{1, threadsPerBlock / 32, 32};
+  dim3 grid{num_blocks(nr, block.x), num_blocks(nq, block.y), num_blocks(np, block.z)};
+  kernel_sum<<<block, grid>>>(nr, nq, np, A, C4, sum);
+}
+
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t nq = pbsize - pbsize / 8;  // 140
+  pbsize_t nr = pbsize - pbsize / 16; // 150
+  pbsize_t np = pbsize;               // 160
+
+
+
+  auto A = state.allocate_array<real>({nr, nq, np}, /*fakedata*/ true, /*verify*/ true, "A");
+  auto C4 = state.allocate_array<real>({np, np}, /*fakedata*/ true, /*verify*/ false, "C4");
+
+
+  real *dev_A = state.allocate_dev_hip<real>(nr * nq * np);
+  real *dev_C4 = state.allocate_dev_hip<real>(np * np);
+  real *dev_sum = state.allocate_dev_hip<real>(nr * nq * np);
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_A, A.data(), nr * nq * np * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_C4, C4.data(), np * np * sizeof(real), hipMemcpyHostToDevice));
+
+    kernel(nr, nq, np, dev_A, dev_C4, dev_sum);
+
+    hipMemcpy(A.data(), dev_sum, nr * nq * np * sizeof(real), hipMemcpyDeviceToHost);
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+  state.free_dev_hip(dev_A);
+  state.free_dev_hip(dev_C4);
+  state.free_dev_hip(dev_sum);
+}

--- a/benchmarks/suites/polybench/fdtd-2d/fdtd-2d.hip
+++ b/benchmarks/suites/polybench/fdtd-2d/fdtd-2d.hip
@@ -1,0 +1,128 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include "rosetta.h"
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+__global__ void kernel_splat(pbsize_t tmax,
+                             pbsize_t nx,
+                             pbsize_t ny,
+                             real *ex, real *ey, real *hz, real fict[], idx_t t) {
+  idx_t j = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (j < ny)
+    ey[0 * ny + j] = fict[t];
+}
+
+
+__global__ void kernel_ey(pbsize_t tmax,
+                          pbsize_t nx,
+                          pbsize_t ny,
+                          real *ex, real *ey, real *hz, real fict[], idx_t t) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x + 1;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+  if (i < nx && j < ny)
+    ey[i * ny + j] -= (real)(0.5) * (hz[i * ny + j] - hz[(i - 1) * ny + j]);
+}
+
+
+
+__global__ void kernel_ex(pbsize_t tmax,
+                          pbsize_t nx,
+                          pbsize_t ny,
+                          real *ex, real *ey, real *hz, real fict[], idx_t t) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y + 1;
+
+  if (i < nx && j < ny)
+    ex[i * ny + j] -= (real)(0.5) * (hz[i * ny + j] - hz[i * ny + j - 1]);
+}
+
+
+
+__global__ void kernel_hz(pbsize_t tmax,
+                          pbsize_t nx,
+                          pbsize_t ny,
+                          real *ex, real *ey, real *hz, real fict[], idx_t t) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+  if (i < nx - 1 && j < ny - 1)
+    hz[i * ny + j] -= (real)(0.7) * (ex[i * ny + j + 1] - ex[i * ny + j] + ey[(i + 1) * ny + j] - ey[i * ny + j]);
+}
+
+
+
+static void kernel(pbsize_t tmax,
+                   pbsize_t nx,
+                   pbsize_t ny,
+                   real *ex, real *ey, real *hz, real fict[]) {
+  const unsigned threadsPerBlock = 256;
+
+  for (idx_t t = 0; t < tmax; t++) {
+    kernel_splat<<<threadsPerBlock, num_blocks(ny, threadsPerBlock)>>>(tmax, nx, ny, ex, ey, hz, fict, t);
+
+    {
+      dim3 block{threadsPerBlock / 32, 32, 1};
+      dim3 grid{num_blocks(nx - 1, block.x), num_blocks(ny, block.y), 1};
+      kernel_ey<<<block, grid>>>(tmax, nx, ny, ex, ey, hz, fict, t);
+    }
+
+
+    {
+      dim3 block{threadsPerBlock / 32, 32, 1};
+      dim3 grid{num_blocks(nx, block.x), num_blocks(ny - 1, block.y), 1};
+      kernel_ex<<<block, grid>>>(tmax, nx, ny, ex, ey, hz, fict, t);
+    }
+
+    {
+      dim3 block{threadsPerBlock / 32, 32, 1};
+      dim3 grid{num_blocks(nx - 1, block.x), num_blocks(ny - 1, block.y), 1};
+      kernel_hz<<<block, grid>>>(tmax, nx, ny, ex, ey, hz, fict, t);
+    }
+  }
+}
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t tmax = 5 * pbsize / 12;   // 500
+  pbsize_t nx = pbsize - pbsize / 6; // 1000
+  pbsize_t ny = pbsize;              // 1200
+
+
+
+  auto ex = state.allocate_array<real>({nx, ny}, /*fakedata*/ true, /*verify*/ true, "ex");
+  auto ey = state.allocate_array<real>({nx, ny}, /*fakedata*/ true, /*verify*/ true, "ey");
+  auto hz = state.allocate_array<real>({nx, ny}, /*fakedata*/ true, /*verify*/ true, "hz");
+  auto fict = state.allocate_array<real>({tmax}, /*fakedata*/ true, /*verify*/ false, "fict");
+
+  real *dev_ex = state.allocate_dev_hip<real>(nx * ny);
+  real *dev_ey = state.allocate_dev_hip<real>(nx * ny);
+  real *dev_hz = state.allocate_dev_hip<real>(nx * ny);
+  real *dev_fict = state.allocate_dev_hip<real>(tmax);
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_ex, ex.data(), nx * ny * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_ey, ey.data(), nx * ny * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_hz, hz.data(), nx * ny * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_fict, fict.data(), tmax * sizeof(real), hipMemcpyHostToDevice));
+
+    kernel(tmax, nx, ny, dev_ex, dev_ey, dev_hz, dev_fict);
+
+    BENCH_HIP_TRY(hipMemcpy(ex.data(), dev_ex, nx * ny * sizeof(real), hipMemcpyDeviceToHost));
+    BENCH_HIP_TRY(hipMemcpy(ey.data(), dev_ey, nx * ny * sizeof(real), hipMemcpyDeviceToHost));
+    BENCH_HIP_TRY(hipMemcpy(hz.data(), dev_hz, nx * ny * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+  state.free_dev_hip(dev_ex);
+  state.free_dev_hip(dev_ey);
+  state.free_dev_hip(dev_hz);
+  state.free_dev_hip(dev_fict);
+}

--- a/benchmarks/suites/polybench/floyd-warshall/floyd-warshall.hip
+++ b/benchmarks/suites/polybench/floyd-warshall/floyd-warshall.hip
@@ -1,0 +1,90 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+template <typename T>
+struct AtomicMin;
+
+template <>
+struct AtomicMin<double> {
+  __device__ static double set_if_smaller(double &dst, double val) {
+    // Store everything as uint64_t to protect from NaNs.
+    unsigned long long int newval = __double_as_longlong(val);
+    unsigned long long int old = *((unsigned long long int *)&dst);
+    while (1) {
+      // Values can only get smaller
+      if (__longlong_as_double(old) <= __longlong_as_double(newval))
+        return __longlong_as_double(old);
+
+      auto assumed = old;
+      auto newold = atomicCAS((unsigned long long int *)&dst, assumed, newval);
+
+      // Three possibilities:
+      // 1. Noone interferred and we set the new min value, even if it was NaN.
+      if (assumed == newold)
+        return __longlong_as_double(old);
+
+      // 2. Someone else overwrote dst with a value between val and old.
+      // Will continue the loop again, same problem except that dst now contains old
+      old = newold;
+
+      // 3. Someone else overwrote dst with a smaller value than val.
+      // dst and old both contains that smallest value
+      // Will break the loop at next iteration because old <= newval
+    }
+  }
+};
+
+
+
+__global__ void kernel_min(pbsize_t n, real *path, idx_t k) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (i < n && j < n)
+    AtomicMin<real>::set_if_smaller(path[i * n + j], path[i * n + k] + path[k * n + j]);
+}
+
+
+
+static void kernel(pbsize_t n, real *path) {
+  const unsigned threadsPerBlock = 256;
+
+  for (idx_t k = 0; k < n; k++) {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(n, block.x), num_blocks(n, block.y), 1};
+    kernel_min<<<block, grid>>>(n, path, k);
+  }
+}
+
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t n = pbsize; // 2800
+
+
+
+  auto path = state.allocate_array<real>({n, n}, /*fakedata*/ true, /*verify*/ true, "path");
+
+  real *dev_path = state.allocate_dev_hip<real>(n * n);
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_path, path.data(), n * n * sizeof(real), hipMemcpyHostToDevice));
+
+    kernel(n, dev_path);
+
+
+    BENCH_HIP_TRY(hipMemcpy(path.data(), dev_path, n * n * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+  state.free_dev_hip(dev_path);
+}

--- a/benchmarks/suites/polybench/gemm/gemm.hip
+++ b/benchmarks/suites/polybench/gemm/gemm.hip
@@ -1,0 +1,78 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include "rosetta.h"
+
+
+
+__global__ void kernel_dev(pbsize_t ni, pbsize_t nj, pbsize_t nk,
+                           real alpha,
+                           real beta,
+                           real *C, real *A, real *B) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (i < ni && j < nj) {
+    C[i * nj + j] *= beta;
+
+
+    for (idx_t k = 0; k < nk; k++)
+      C[i * nj + j] += alpha * A[i * nk + k] * B[k * nj + j];
+  }
+}
+
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+static void kernel(pbsize_t ni, pbsize_t nj, pbsize_t nk,
+                   real alpha,
+                   real beta,
+                   real *C, real *A, real *B) {
+
+  unsigned threadsPerBlock = 256;
+  dim3 block{threadsPerBlock / 32, 32, 1};
+  dim3 grid{num_blocks(ni, block.x), num_blocks(nj, block.y), 1};
+  kernel_dev<<<block, grid>>>(ni, nj, nk, alpha, beta, C, A, B);
+}
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t ni = pbsize - pbsize / 4;
+  pbsize_t nj = pbsize - pbsize / 8;
+  pbsize_t nk = pbsize;
+
+  real alpha = 1.5;
+  real beta = 1.2;
+  auto C = state.allocate_array<real>({ni, nj}, /*fakedata*/ true, /*verify*/ true, "C");
+  auto A = state.allocate_array<real>({ni, nk}, /*fakedata*/ true, /*verify*/ false, "A");
+  auto B = state.allocate_array<real>({nk, nj}, /*fakedata*/ true, /*verify*/ false, "B");
+
+
+  real *dev_C = state.allocate_dev_hip<real>(ni * nj);
+  real *dev_A = state.allocate_dev_hip<real>(ni * nk);
+  real *dev_B = state.allocate_dev_hip<real>(nk * nj);
+
+  for (auto &&_ : state) {
+    hipMemcpy(dev_C, C.data(), ni * nj * sizeof(real), hipMemcpyHostToDevice);
+    hipMemcpy(dev_A, A.data(), ni * nk * sizeof(real), hipMemcpyHostToDevice);
+    hipMemcpy(dev_B, B.data(), nk * nj * sizeof(real), hipMemcpyHostToDevice);
+
+
+
+    kernel(ni, nj, nk, alpha, beta, dev_C, dev_A, dev_B);
+
+
+    hipMemcpy(C.data(), dev_C, ni * nj * sizeof(real), hipMemcpyDeviceToHost);
+
+    hipDeviceSynchronize();
+  }
+
+  state.free_dev_hip(dev_C);
+  state.free_dev_hip(dev_A);
+  state.free_dev_hip(dev_B);
+}

--- a/benchmarks/suites/polybench/gemver/gemver.hip
+++ b/benchmarks/suites/polybench/gemver/gemver.hip
@@ -1,0 +1,127 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include "rosetta.h"
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+__global__ void kernel_A(pbsize_t n, real alpha, real beta,
+                         real *A, real *u1, real *v1, real *u2, real *v2, real *w, real *x, real *y, real *z) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+  if (i < n && j < n)
+    A[i * n + j] += u1[i] * v1[j] + u2[i] * v2[j];
+}
+
+
+__global__ void kernel_x(pbsize_t n, real alpha, real beta,
+                         real *A, real *u1, real *v1, real *u2, real *v2, real *w, real *x, real *y, real *z) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+
+
+  if (i < n) {
+    for (idx_t j = 0; j < n; j++)
+      x[i] += beta * A[j * n + i] * y[j];
+  }
+}
+
+
+__global__ void kernel_y(pbsize_t n, real alpha, real beta,
+                         real *A, real *u1, real *v1, real *u2, real *v2, real *w, real *x, real *y, real *z) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+
+
+  if (i < n)
+    x[i] += z[i];
+}
+
+__global__ void kernel_w(pbsize_t n, real alpha, real beta,
+                         real *A, real *u1, real *v1, real *u2, real *v2, real *w, real *x, real *y, real *z) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+
+
+  if (i < n) {
+    for (idx_t j = 0; j < n; j++)
+      w[i] += alpha * A[i * n + j] * x[j];
+  }
+}
+
+
+
+static void kernel(pbsize_t n, real alpha, real beta,
+                   real *A, real *u1, real *v1, real *u2, real *v2, real *w, real *x, real *y, real *z) {
+  const unsigned threadsPerBlock = 256;
+
+
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(n, block.x), num_blocks(n, block.y), 1};
+    kernel_A<<<block, grid>>>(n, alpha, beta, A, u1, v1, u2, v2, w, x, y, z);
+  }
+
+
+  kernel_x<<<threadsPerBlock, num_blocks(n, threadsPerBlock)>>>(n, alpha, beta, A, u1, v1, u2, v2, w, x, y, z);
+  kernel_y<<<threadsPerBlock, num_blocks(n, threadsPerBlock)>>>(n, alpha, beta, A, u1, v1, u2, v2, w, x, y, z);
+  kernel_w<<<threadsPerBlock, num_blocks(n, threadsPerBlock)>>>(n, alpha, beta, A, u1, v1, u2, v2, w, x, y, z);
+}
+
+
+
+void run(State &state, pbsize_t n) {
+  real alpha = 1.5;
+  real beta = 1.2;
+  auto y = state.allocate_array<double>({n}, /*fakedata*/ true, /*verify*/ false, "y");
+  auto z = state.allocate_array<double>({n}, /*fakedata*/ true, /*verify*/ false, "z");
+  auto u1 = state.allocate_array<double>({n}, /*fakedata*/ true, /*verify*/ false, "u1");
+  auto v1 = state.allocate_array<double>({n}, /*fakedata*/ true, /*verify*/ false, "v1");
+  auto u2 = state.allocate_array<double>({n}, /*fakedata*/ true, /*verify*/ false, "u2");
+  auto v2 = state.allocate_array<double>({n}, /*fakedata*/ true, /*verify*/ false, "v2");
+  auto A = state.allocate_array<double>({n, n}, /*fakedata*/ true, /*verify*/ true, "A");
+  auto w = state.allocate_array<double>({n}, /*fakedata*/ true, /*verify*/ true, "w");
+  auto x = state.allocate_array<double>({n}, /*fakedata*/ true, /*verify*/ true, "x");
+
+  real *dev_y = state.allocate_dev_hip<real>(n);
+  real *dev_z = state.allocate_dev_hip<real>(n);
+  real *dev_u1 = state.allocate_dev_hip<real>(n);
+  real *dev_v1 = state.allocate_dev_hip<real>(n);
+  real *dev_u2 = state.allocate_dev_hip<real>(n);
+  real *dev_v2 = state.allocate_dev_hip<real>(n);
+  real *dev_A = state.allocate_dev_hip<real>(n * n);
+  real *dev_w = state.allocate_dev_hip<real>(n);
+  real *dev_x = state.allocate_dev_hip<real>(n);
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_y, y.data(), n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_z, z.data(), n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_u1, u1.data(), n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_v1, v1.data(), n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_u2, u2.data(), n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_v2, v2.data(), n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_A, A.data(), n * n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_w, w.data(), n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_x, x.data(), n * sizeof(real), hipMemcpyHostToDevice));
+
+    kernel(n, alpha, beta, dev_A, dev_u1, dev_v1, dev_u2, dev_v2, dev_w, dev_x, dev_y, dev_z);
+
+    BENCH_HIP_TRY(hipMemcpy(A.data(), dev_A, n * n * sizeof(real), hipMemcpyDeviceToHost));
+    BENCH_HIP_TRY(hipMemcpy(w.data(), dev_w, n * sizeof(real), hipMemcpyDeviceToHost));
+    BENCH_HIP_TRY(hipMemcpy(x.data(), dev_x, n * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+
+  state.free_dev_hip(dev_y);
+  state.free_dev_hip(dev_z);
+  state.free_dev_hip(dev_u1);
+  state.free_dev_hip(dev_v1);
+  state.free_dev_hip(dev_u2);
+  state.free_dev_hip(dev_v2);
+  state.free_dev_hip(dev_A);
+  state.free_dev_hip(dev_w);
+  state.free_dev_hip(dev_x);
+}

--- a/benchmarks/suites/polybench/gesummv/gesummv.hip
+++ b/benchmarks/suites/polybench/gesummv/gesummv.hip
@@ -1,0 +1,79 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include "rosetta.h"
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+__global__ void kernel_y(pbsize_t n,
+                         real alpha, real beta,
+                         real *A,
+                         real *B,
+                         real tmp[],
+                         real x[],
+                         real y[]) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+
+
+
+  if (i < n) {
+    tmp[i] = 0;
+    y[i] = 0;
+    for (idx_t j = 0; j < n; j++) {
+      tmp[i] += A[i * n + j] * x[j];
+      y[i] += B[i * n + j] * x[j];
+    }
+    y[i] = alpha * tmp[i] + beta * y[i];
+  }
+}
+
+
+
+static void kernel(pbsize_t n,
+                   real alpha, real beta,
+                   real *A,
+                   real *B,
+                   real tmp[],
+                   real x[],
+                   real y[]) {
+  const unsigned threadsPerBlock = 256;
+  kernel_y<<<threadsPerBlock, num_blocks(n, threadsPerBlock)>>>(n, alpha, beta, A, B, tmp, x, y);
+}
+
+
+
+void run(State &state, pbsize_t n) {
+  real alpha = 1.5;
+  real beta = 1.2;
+  auto A = state.allocate_array<double>({n, n}, /*fakedata*/ true, /*verify*/ false, "A");
+  auto B = state.allocate_array<double>({n, n}, /*fakedata*/ true, /*verify*/ false, "B");
+  auto x = state.allocate_array<double>({n}, /*fakedata*/ true, /*verify*/ false, "x");
+  auto y = state.allocate_array<double>({n}, /*fakedata*/ false, /*verify*/ true, "y");
+
+
+  real *dev_A = state.allocate_dev_hip<real>(n * n);
+  real *dev_B = state.allocate_dev_hip<real>(n * n);
+  real *dev_tmp = state.allocate_dev_hip<real>(n);
+  real *dev_x = state.allocate_dev_hip<real>(n);
+  real *dev_y = state.allocate_dev_hip<real>(n);
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_A, A.data(), n * n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_B, B.data(), n * n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_x, x.data(), n * sizeof(real), hipMemcpyHostToDevice));
+
+    kernel(n, alpha, beta, dev_A, dev_B, dev_tmp, dev_x, dev_y);
+
+    BENCH_HIP_TRY(hipMemcpy(y.data(), dev_y, n * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+  state.free_dev_hip(dev_A);
+  state.free_dev_hip(dev_B);
+  state.free_dev_hip(dev_tmp);
+  state.free_dev_hip(dev_x);
+  state.free_dev_hip(dev_y);
+}

--- a/benchmarks/suites/polybench/heat-3d/heat-3d.hip
+++ b/benchmarks/suites/polybench/heat-3d/heat-3d.hip
@@ -1,0 +1,75 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+__global__ void kernel_stencil(pbsize_t n, real *A, real *B) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x + 1;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y + 1;
+  idx_t k = blockDim.z * blockIdx.z + threadIdx.z + 1;
+
+  if (i < n - 1 && j < n - 1 && k < n - 1) {
+    B[(i * n + j) * n + k] = (A[((i + 1) * n + j) * n + k] - 2 * A[(i * n + j) * n + k] + A[((i - 1) * n + j) * n + k]) / 8 + (A[(i * n + (j + 1)) * n + k] - 2 * A[(i * n + j) * n + k] + A[(i * n + (j - 1)) * n + k]) / 8 + (A[(i * n + j) * n + k + 1] - 2 * A[(i * n + j) * n + k] + A[(i * n + j) * n + k - 1]) / 8 + A[(i * n + j) * n + k];
+  }
+}
+
+
+
+static void kernel(pbsize_t tsteps, pbsize_t n, real *A, real *B) {
+  const unsigned int threadsPerBlock = 256;
+
+  for (idx_t t = 1; t <= tsteps; t++) {
+    dim3 block{1, threadsPerBlock / 32, 32};
+    dim3 grid{num_blocks(n - 2, block.x), num_blocks(n - 2, block.y), num_blocks(n - 2, block.z)};
+    kernel_stencil<<<block, grid>>>(n, A, B);
+    kernel_stencil<<<block, grid>>>(n, B, A);
+  }
+}
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t tsteps = 1; // 500
+  pbsize_t n = pbsize; // 120
+
+  // Linear interpolation of tsteps using the formula
+  // Estimated tsteps = tsteps1 + (tsteps2 - tsteps1) * ((pbsize - pbsize1) / (pbsize2 - pbsize1))
+  if (pbsize <= 20) {
+    tsteps = pbsize * 2;
+  } else if (pbsize > 20 && pbsize <= 40) {
+    tsteps = (3 * pbsize) - 20;
+  } else if (pbsize > 40 && pbsize <= 120) {
+    tsteps = (5 * pbsize) - 100;
+  } else if (pbsize > 120) {
+    tsteps = (6.25 * pbsize) - 250;
+  }
+
+
+  auto A = state.allocate_array<real>({n, n, n}, /*fakedata*/ true, /*verify*/ false, "A");
+  auto B = state.allocate_array<real>({n, n, n}, /*fakedata*/ false, /*verify*/ true, "B");
+
+  real *dev_A = state.allocate_dev_hip<real>(n * n * n);
+  real *dev_B = state.allocate_dev_hip<real>(n * n * n);
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_A, A.data(), n * n * n * sizeof(real), hipMemcpyHostToDevice));
+
+
+    kernel(tsteps, n, dev_A, dev_B);
+
+
+    BENCH_HIP_TRY(hipMemcpy(B.data(), dev_B, n * n * n * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+
+  state.free_dev_hip(dev_A);
+  state.free_dev_hip(dev_B);
+}

--- a/benchmarks/suites/polybench/jacobi-1d/jacobi-1d.hip
+++ b/benchmarks/suites/polybench/jacobi-1d/jacobi-1d.hip
@@ -1,0 +1,58 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+__global__ void kernel_stencil(pbsize_t n, real A[], real B[]) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x + 1;
+
+
+  if (i < n - 1) {
+    B[i] = (A[i - 1] + A[i] + A[i + 1]) / 3;
+  }
+}
+
+
+
+static void kernel(pbsize_t tsteps, pbsize_t n, real A[], real B[]) {
+  const unsigned int threadsPerBlock = 256;
+
+  for (idx_t t = 1; t <= tsteps; t++) {
+    kernel_stencil<<<threadsPerBlock, num_blocks(n, threadsPerBlock)>>>(n, A, B);
+    kernel_stencil<<<threadsPerBlock, num_blocks(n, threadsPerBlock)>>>(n, B, A);
+  }
+}
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t tsteps = 1; // 500
+  pbsize_t n = pbsize; // 2000
+
+
+
+  auto A = state.allocate_array<real>({n}, /*fakedata*/ true, /*verify*/ false, "A");
+  auto B = state.allocate_array<real>({n}, /*fakedata*/ false, /*verify*/ true, "B");
+
+  real *dev_A = state.allocate_dev_hip<real>(n);
+  real *dev_B = state.allocate_dev_hip<real>(n);
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_A, A.data(), n * sizeof(real), hipMemcpyHostToDevice));
+
+    kernel(tsteps, n, dev_A, dev_B);
+
+    BENCH_HIP_TRY(hipMemcpy(B.data(), dev_B, n * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+  state.free_dev_hip(dev_A);
+  state.free_dev_hip(dev_B);
+}

--- a/benchmarks/suites/polybench/jacobi-2d/jacobi-2d.hip
+++ b/benchmarks/suites/polybench/jacobi-2d/jacobi-2d.hip
@@ -1,0 +1,59 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+__global__ void kernel_stencil(pbsize_t n, real *A, real *B) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x + 1;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y + 1;
+
+
+  if (i < n - 1 && j < n - 1) {
+    B[i * n + j] = (A[i * n + j] + A[i * n + j - 1] + A[i * n + 1 + j] + A[(1 + i) * n + j] + A[(i - 1) * n + j]) / 5;
+  }
+}
+
+
+
+static void kernel(pbsize_t tsteps, pbsize_t n,
+                   real *A, real *B) {
+  const unsigned int threadsPerBlock = 256;
+
+  for (idx_t t = 1; t <= tsteps; t++) {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(n - 2, block.x), num_blocks(n - 2, block.y), 1};
+    kernel_stencil<<<block, grid>>>(n, A, B);
+    kernel_stencil<<<block, grid>>>(n, B, A);
+  }
+}
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t tsteps = 1; // 500
+  pbsize_t n = pbsize; // 1300
+
+
+
+  auto A = state.allocate_array<real>({n, n}, /*fakedata*/ true, /*verify*/ false, "A");
+  auto B = state.allocate_array<real>({n, n}, /*fakedata*/ false, /*verify*/ true, "B");
+
+  real *dev_A = state.allocate_dev_hip<real>(n * n);
+  real *dev_B = state.allocate_dev_hip<real>(n * n);
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_A, A.data(), n * n * sizeof(real), hipMemcpyHostToDevice));
+    kernel(tsteps, n, dev_A, dev_B);
+    BENCH_HIP_TRY(hipMemcpy(B.data(), dev_B, n * n * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+  state.free_dev_hip(dev_A);
+  state.free_dev_hip(dev_B);
+}

--- a/benchmarks/suites/polybench/lu/lu.hip
+++ b/benchmarks/suites/polybench/lu/lu.hip
@@ -1,0 +1,73 @@
+// BUILD: add_benchmark(ppm=hip,sources=[__file__,"lu-common.cxx"])
+
+#include "lu-common.h"
+#include <rosetta.h>
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+__global__ void kernel_div(pbsize_t n, real *A, idx_t k) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x + k + 1;
+
+
+
+  if (i < n)
+    A[i * n + k] /= A[k * n + k];
+}
+
+
+
+__global__ void kernel_A(pbsize_t n, real *A, idx_t k) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x + k + 1;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y + k + 1;
+
+
+  if (i < n && j < n)
+    A[i * n + j] -= A[i * n + k] * A[k * n + j];
+}
+
+
+
+static void
+kernel(pbsize_t n, real *A) {
+  const unsigned int threadsPerBlock = 256;
+
+  for (idx_t k = 0; k < n - 1; k++) {
+    kernel_div<<<threadsPerBlock, num_blocks(n - (k + 1), threadsPerBlock)>>>(n, A, k);
+
+
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(n - (k + 1), block.x), num_blocks(n - (k + 1), block.y), 1};
+    kernel_A<<<block, grid>>>(n, A, k);
+  }
+}
+
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t n = pbsize; // 2000
+
+
+  auto A = state.allocate_array<real>({n, n}, /*fakedata*/ true, /*verify*/ true, "A");
+
+  real *dev_A = state.allocate_dev_hip<real>(n * n);
+
+  for (auto &&_ : state.manual()) {
+    ensure_fullrank(n, A);
+    {
+      auto &&scope = _.scope();
+
+
+      BENCH_HIP_TRY(hipMemcpy(dev_A, A.data(), n * n * sizeof(real), hipMemcpyHostToDevice));
+      kernel(n, dev_A);
+      BENCH_HIP_TRY(hipMemcpy(A.data(), dev_A, n * n * sizeof(real), hipMemcpyDeviceToHost));
+
+      BENCH_HIP_TRY(hipDeviceSynchronize());
+    }
+  }
+
+  state.free_dev_hip(dev_A);
+}

--- a/benchmarks/suites/polybench/ludcmp/ludcmp.hip
+++ b/benchmarks/suites/polybench/ludcmp/ludcmp.hip
@@ -1,0 +1,196 @@
+// BUILD: add_benchmark(ppm=hip,sources=[__file__,"ludcmp-common.cxx"])
+
+#include "ludcmp-common.h"
+
+#include <rosetta.h>
+
+#include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/for_each.h>
+#include <thrust/functional.h>
+#include <thrust/host_vector.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/reduce.h>
+#include <thrust/transform_reduce.h>
+
+
+
+struct minus_Aik_times_Akj : public thrust::unary_function<real, real> {
+  pbsize_t n;
+  thrust::device_ptr<real> A;
+  idx_t i;
+  idx_t j;
+
+  minus_Aik_times_Akj(pbsize_t n, thrust::device_ptr<real> A, idx_t i, idx_t j) : n(n), A(A), i(i), j(j) {}
+
+  __host__ __device__ real operator()(pbsize_t k) const {
+    return -(A[i * n + k] * A[k * n + j]);
+  }
+};
+
+struct minus_Aij_times_yj : public thrust::unary_function<real, real> {
+  pbsize_t n;
+  thrust::device_ptr<real> A;
+  thrust::device_ptr<real> y;
+  idx_t i;
+
+
+  minus_Aij_times_yj(pbsize_t n, thrust::device_ptr<real> A, thrust::device_ptr<real> y, idx_t i) : n(n), A(A), y(y), i(i) {}
+
+  __host__ __device__ real operator()(pbsize_t j) const {
+    return -(A[i * n + j] * y[j]);
+  }
+};
+
+
+
+struct minus_Aij_times_xj : public thrust::unary_function<real, real> {
+  pbsize_t n;
+  thrust::device_ptr<real> A;
+  thrust::device_ptr<real> x;
+  idx_t i;
+
+
+  minus_Aij_times_xj(pbsize_t n, thrust::device_ptr<real> A, thrust::device_ptr<real> x, idx_t i) : n(n), A(A), x(x), i(i) {}
+
+  __host__ __device__ real operator()(pbsize_t j) const {
+    return -(A[i * n + j] * x[j]);
+  }
+};
+
+
+
+static void kernel(pbsize_t n, thrust::device_ptr<real> A, thrust::device_ptr<real> b, thrust::device_ptr<real> x, thrust::device_ptr<real> y) {
+  // TODO: The LU-Decomposition is identical to suites.polyench.lu, should use comparable algorithms.
+  for (idx_t i = 0; i < n; i++) {
+    for (idx_t j = 0; j < i; j++) {
+      real w = A[i * n + j];
+      minus_Aik_times_Akj op{n, A, i, j};
+      w = thrust::transform_reduce(
+          thrust::device,
+          thrust::make_counting_iterator(0),
+          thrust::make_counting_iterator(0) + j,
+          op,
+          w,
+          thrust::plus<real>());
+      A[i * n + j] = w / A[j * n + j];
+    }
+    for (idx_t j = i; j < n; j++) {
+      real w = A[i * n + j];
+      minus_Aik_times_Akj op{n, A, i, j};
+      w = thrust::transform_reduce(
+          thrust::device,
+          thrust::make_counting_iterator(0),
+          thrust::make_counting_iterator(0) + i,
+          op,
+          w,
+          thrust::plus<real>());
+      A[i * n + j] = w;
+    }
+
+    for (idx_t i = 0; i < n; i++) {
+      real w = b[i];
+      minus_Aij_times_yj op{n, A, y, i};
+      w = thrust::transform_reduce(
+          thrust::device,
+          thrust::make_counting_iterator(0),
+          thrust::make_counting_iterator(0) + i,
+          op,
+          w,
+          thrust::plus<real>());
+      y[i] = w;
+    }
+    for (idx_t i = n - 1; i >= 0; i--) {
+      real w = y[i];
+      minus_Aij_times_xj op{n, A, x, i};
+      w = thrust::transform_reduce(
+          thrust::device,
+          thrust::make_counting_iterator(0) + i + 1,
+          thrust::make_counting_iterator(0) + n,
+          op,
+          w,
+          thrust::plus<real>());
+      x[i] = w / A[i * n + i];
+    }
+  }
+
+
+#if 0
+  for (idx_t i = 0; i < n; i++) {
+    for (idx_t  j = 0; j < i; j++) {
+      real w = A[i][j];
+#pragma omp parallel for default(none) firstprivate(i, j, n, A) schedule(static) reduction(+ \
+                                                                                           : w)
+      for (idx_t k = 0; k < j; k++) 
+        w -= A[i][k] * A[k][j];
+      A[i][j] = w / A[j][j];
+    }
+    for (idx_t j = i; j < n; j++) {
+      real w = A[i][j];
+#pragma omp parallel for default(none) firstprivate(i, j, n, A) schedule(static) reduction(+ \
+                                                                                           : w)
+      for (idx_t k = 0; k < i; k++) 
+        w -= A[i][k] * A[k][j];
+      A[i][j] = w;
+    }
+  }
+
+  for (idx_t i = 0; i < n; i++) {
+    real w = b[i];
+#pragma omp parallel for default(none) firstprivate(i, n, A, y) schedule(static) reduction(+ \
+                                                                                           : w)
+    for (idx_t j = 0; j < i; j++)
+      w -= A[i][j] * y[j];
+    y[i] = w;
+  }
+
+  for (idx_t i = n - 1; i >= 0; i--) {
+    real w = y[i];
+#pragma omp parallel for default(none) firstprivate(i, n, A, x) schedule(static) reduction(+ \
+                                                                                           : w)
+    for (idx_t j = i + 1; j < n; j++)
+      w -= A[i][j] * x[j];
+    x[i] = w / A[i][i];
+  }
+#endif
+}
+
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t n = pbsize; // 2000
+
+
+
+  auto A = state.allocate_array<real>({n, n}, /*fakedata*/ true, /*verify*/ false, "A");
+  auto b = state.allocate_array<real>({n}, /*fakedata*/ true, /*verify*/ false, "b");
+  auto x = state.allocate_array<real>({n}, /*fakedata*/ false, /*verify*/ true, "x");
+
+
+
+  real *dev_A = state.allocate_dev_hip<real>(n * n);
+  real *dev_b = state.allocate_dev_hip<real>(n);
+  real *dev_x = state.allocate_dev_hip<real>(n);
+  real *dev_y = state.allocate_dev_hip<real>(n);
+
+  for (auto &&_ : state.manual()) {
+    ensure_fullrank(n, A);
+    {
+      auto &&scope = _.scope();
+
+      BENCH_HIP_TRY(hipMemcpy(dev_A, A.data(), n * n * sizeof(real), hipMemcpyHostToDevice));
+      BENCH_HIP_TRY(hipMemcpy(dev_b, b.data(), n * sizeof(real), hipMemcpyHostToDevice));
+      kernel(n, thrust::device_pointer_cast(dev_A), thrust::device_pointer_cast(dev_b), thrust::device_pointer_cast(dev_x), thrust::device_pointer_cast(dev_y));
+      BENCH_HIP_TRY(hipMemcpy(x.data(), dev_x, n * sizeof(real), hipMemcpyDeviceToHost));
+
+
+      BENCH_HIP_TRY(hipDeviceSynchronize());
+    }
+  }
+
+  state.free_dev_hip(dev_A);
+  state.free_dev_hip(dev_b);
+  state.free_dev_hip(dev_x);
+  state.free_dev_hip(dev_y);
+}

--- a/benchmarks/suites/polybench/mvt/mvt.hip
+++ b/benchmarks/suites/polybench/mvt/mvt.hip
@@ -1,0 +1,94 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+__global__ void kernel_x1(pbsize_t n,
+                          real x1[],
+                          real x2[],
+                          real y_1[],
+                          real y_2[],
+                          real *A) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (i < n) {
+    for (idx_t j = 0; j < n; j++)
+      x1[i] += A[i * n + j] * y_1[j];
+  }
+}
+
+
+__global__ void kernel_x2(pbsize_t n,
+                          real x1[],
+                          real x2[],
+                          real y_1[],
+                          real y_2[],
+                          real *A) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+
+  if (i < n) {
+    for (idx_t j = 0; j < n; j++)
+      x2[i] += A[j * n + i] * y_2[j];
+  }
+}
+
+
+
+static void kernel(pbsize_t n,
+                   real x1[],
+                   real x2[],
+                   real y_1[],
+                   real y_2[],
+                   real *A) {
+  const unsigned threadsPerBlock = 256;
+
+
+  kernel_x1<<<threadsPerBlock, num_blocks(n, threadsPerBlock)>>>(n, x1, x2, y_1, y_2, A);
+  kernel_x2<<<threadsPerBlock, num_blocks(n, threadsPerBlock)>>>(n, x1, x2, y_1, y_2, A);
+}
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t n = pbsize; // 2000
+
+
+
+  auto A = state.allocate_array<real>({n, n}, /*fakedata*/ true, /*verify*/ false, "A");
+  auto x1 = state.allocate_array<real>({n}, /*fakedata*/ true, /*verify*/ true, "x1");
+  auto x2 = state.allocate_array<real>({n}, /*fakedata*/ true, /*verify*/ true, "x2");
+  auto y_1 = state.allocate_array<real>({n}, /*fakedata*/ true, /*verify*/ false, "y_1");
+  auto y_2 = state.allocate_array<real>({n}, /*fakedata*/ true, /*verify*/ false, "y_2");
+
+
+  real *dev_A = state.allocate_dev_hip<real>(n * n);
+  real *dev_x1 = state.allocate_dev_hip<real>(n);
+  real *dev_x2 = state.allocate_dev_hip<real>(n);
+  real *dev_y_1 = state.allocate_dev_hip<real>(n);
+  real *dev_y_2 = state.allocate_dev_hip<real>(n);
+
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_A, A.data(), n * n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_x1, x1.data(), n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_x2, x2.data(), n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_y_1, y_1.data(), n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_y_2, y_2.data(), n * sizeof(real), hipMemcpyHostToDevice));
+    kernel(n, dev_x1, dev_x2, dev_y_1, dev_y_2, dev_A);
+    BENCH_HIP_TRY(hipMemcpy(x1.data(), dev_x1, n * sizeof(real), hipMemcpyDeviceToHost));
+    BENCH_HIP_TRY(hipMemcpy(x2.data(), dev_x2, n * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+  state.free_dev_hip(dev_A);
+  state.free_dev_hip(dev_x1);
+  state.free_dev_hip(dev_x2);
+  state.free_dev_hip(dev_y_1);
+  state.free_dev_hip(dev_y_2);
+}

--- a/benchmarks/suites/polybench/nussinov/nussinov.hip
+++ b/benchmarks/suites/polybench/nussinov/nussinov.hip
@@ -1,0 +1,81 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+// Dynamic programming wavefront
+__global__ void kernel_max_score(pbsize_t n, real seq[], real table[], real oldtable[], idx_t w) {
+  idx_t j = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t i = ((idx_t)n - 1) + j - w;
+
+  if (0 <= i && i < n && i + 1 <= j && j < n) {
+    real maximum = table[i * n + j];
+
+    if (j - 1 >= 0)
+      maximum = max(maximum, table[i * n + (j - 1)]);
+    if (i + 1 < n)
+      maximum = max(maximum, table[(i + 1) * n + j]);
+
+    if (j - 1 >= 0 && i + 1 < n) {
+      auto upd = table[(i + 1) * n + (j - 1)];
+
+      /* don't allow adjacent elements to bond */
+      if (i < j - 1)
+        upd += (seq[i] + seq[j] == 3) ? (real)1 : (real)0;
+
+      maximum = max(maximum, upd);
+    }
+
+    for (idx_t k = i + 1; k < j; k++)
+      maximum = max(maximum, table[i * n + k] + table[(k + 1) * n + j]);
+
+    //  AtomicMax<real>::set_if_larger(table[i * n + j], maximum);
+    table[i * n + j] = maximum;
+  }
+}
+
+
+
+static void kernel(pbsize_t n, real seq[], real table[], real oldtable[]) {
+  const unsigned threadsPerBlock = 32;
+
+  for (idx_t w = n; w < 2 * n - 1; ++w) { // wavefronting
+    kernel_max_score<<<num_blocks(n, threadsPerBlock), threadsPerBlock>>>(n, seq, table, oldtable, w);
+  }
+}
+
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t n = pbsize; // 2500
+
+
+
+  auto seq = state.allocate_array<real>({n}, /*fakedata*/ true, /*verify*/ false, "seq");
+  auto table = state.allocate_array<real>({n, n}, /*fakedata*/ true, /*verify*/ true, "table");
+
+  real *dev_seq = state.allocate_dev_hip<real>(n);
+  real *dev_table = state.allocate_dev_hip<real>(n * n);
+  real *dev_oldtable = state.allocate_dev_hip<real>(n * n);
+
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_seq, seq.data(), n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_table, table.data(), n * n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_oldtable, dev_table, n * n * sizeof(real), hipMemcpyDeviceToDevice));
+    kernel(n, dev_seq, dev_table, dev_oldtable);
+    BENCH_HIP_TRY(hipMemcpy(table.data(), dev_table, n * n * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+  state.free_dev_hip(dev_seq);
+  state.free_dev_hip(dev_table);
+  state.free_dev_hip(dev_oldtable);
+}

--- a/benchmarks/suites/polybench/seidel-2d/seidel-2d.hip
+++ b/benchmarks/suites/polybench/seidel-2d/seidel-2d.hip
@@ -1,0 +1,64 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+
+__global__ void kernel_stencil(pbsize_t tsteps, pbsize_t n,
+                               real *A) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x + 1;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y + 1;
+
+
+  if (i < n - 1 && j < n - 1)
+    A[i * n + j] = (A[(i - 1) * n + j - 1] +
+                    A[(i - 1) * n + j] +
+                    A[(i - 1) * n + j + 1] +
+                    A[i * n + j - 1] +
+                    A[i * n + j] +
+                    A[i * n + j + 1] +
+                    A[(i + 1) * n + j - 1] +
+                    A[(i + 1) * n + j] +
+                    A[(i + 1) * n + j + 1]) /
+                   9;
+}
+
+
+
+static void kernel(pbsize_t tsteps, pbsize_t n,
+                   real *A) {
+  // FIXME: Parallelizing this should give different results
+  const unsigned int threadsPerBlock = 256;
+
+  for (idx_t t = 1; t <= tsteps; t++) {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(n - 2, block.x), num_blocks(n - 2, block.y), 1};
+    kernel_stencil<<<block, grid>>>(tsteps, n, A);
+  }
+}
+
+
+void run(State &state, int pbsize) {
+  pbsize_t tsteps = 1; // 500
+  pbsize_t n = pbsize; // 2000
+
+
+  // Changed verify to false. Result is non-deterministic by the algorithm by design
+  auto A = state.allocate_array<real>({n, n}, /*fakedata*/ true, /*verify*/ false, "A");
+
+  real *dev_A = state.allocate_dev_hip<real>(n * n);
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_A, A.data(), n * n * sizeof(real), hipMemcpyHostToDevice));
+    kernel(tsteps, n, dev_A);
+    BENCH_HIP_TRY(hipMemcpy(A.data(), dev_A, n * n * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+  state.free_dev_hip(dev_A);
+}

--- a/benchmarks/suites/polybench/symm/symm.hip
+++ b/benchmarks/suites/polybench/symm/symm.hip
@@ -1,0 +1,146 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+__global__ void kernel_tmp(pbsize_t m, pbsize_t n,
+                           real alpha, real beta,
+                           real *C,
+                           real *A,
+                           real *B, real *tmp) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (i < m && j < n) {
+    tmp[i * n + j] = 0;
+    for (idx_t k = 0; k < i; k++)
+      tmp[i * n + j] += B[k * n + j] * A[i * m + k];
+  }
+}
+
+
+__global__ void kernel_C(pbsize_t m, pbsize_t n,
+                         real alpha, real beta,
+                         real *C,
+                         real *A,
+                         real *B, real *tmp) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (i < m && j < n)
+    C[i * n + j] = beta * C[i * n + j] + alpha * B[i * n + j] * A[i * m + i] + alpha * tmp[i * n + j];
+}
+
+
+__global__ void kernel_sum(pbsize_t m, pbsize_t n,
+                           real alpha, real beta,
+                           real *C,
+                           real *A,
+                           real *B, real *tmp) {
+  idx_t k = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (k < m - 1 && j < n) {
+    for (idx_t i = k + 1; i < m; i++)
+      C[k * n + j] += alpha * B[i * n + j] * A[i * m + k];
+  }
+}
+
+
+
+static void kernel(pbsize_t m, pbsize_t n,
+                   real alpha, real beta,
+                   real *C,
+                   real *A,
+                   real *B, real *tmp) {
+  const unsigned int threadsPerBlock = 256;
+
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(m, block.x), num_blocks(n, block.y), 1};
+    kernel_tmp<<<block, grid>>>(m, n, alpha, beta, C, A, B, tmp);
+  }
+
+
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(m, block.x), num_blocks(n, block.y), 1};
+    kernel_C<<<block, grid>>>(m, n, alpha, beta, C, A, B, tmp);
+  }
+
+  // TODO: Combine both kernels?
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(m - 1, block.x), num_blocks(n, block.y), 1};
+    kernel_sum<<<block, grid>>>(m, n, alpha, beta, C, A, B, tmp);
+  }
+
+
+#if 0
+#pragma omp parallel default(none) firstprivate(m, n, alpha, beta, C, A, B, tmp) 
+                       {
+
+
+#pragma omp for collapse(2) schedule(static)
+                           for (idx_t i = 0; i < m; i++)
+                               for (idx_t j = 0; j < n; j++) {
+                                   tmp[i][j] = 0;
+                                   for (idx_t k = 0; k < i; k++)
+                                       tmp[i][j] += B[k][j] * A[i][k];
+                               }
+
+#pragma omp for collapse(2) schedule(static)
+                           for (idx_t i = 0; i < m; i++)
+                               for (idx_t j = 0; j < n; j++)
+                                   C[i][j] = beta * C[i][j] + alpha * B[i][j] * A[i][i] + alpha * tmp[i][j];
+
+#pragma omp for collapse(2) 
+for (idx_t k = 0; k < m - 1; k++)
+                           for (idx_t j = 0; j < n; j++)
+                                   for (idx_t i = k + 1; i < m; i++)
+                                       C[k][j] += alpha * B[i][j] * A[i][k];
+                       }
+#endif
+}
+
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t n = pbsize;
+  pbsize_t m = pbsize - pbsize / 8;
+
+
+  real alpha = 1.5;
+  real beta = 1.2;
+  auto C = state.allocate_array<real>({m, n}, /*fakedata*/ false, /*verify*/ true, "C");
+  auto A = state.allocate_array<real>({m, m}, /*fakedata*/ true, /*verify*/ false, "A");
+  auto B = state.allocate_array<real>({m, n}, /*fakedata*/ true, /*verify*/ false, "B");
+
+
+  real *dev_C = state.allocate_dev_hip<real>(m * n);
+  real *dev_A = state.allocate_dev_hip<real>(m * m);
+  real *dev_B = state.allocate_dev_hip<real>(m * n);
+  real *dev_tmp = state.allocate_dev_hip<real>(m * n);
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_A, A.data(), m * m * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_B, B.data(), m * n * sizeof(real), hipMemcpyHostToDevice));
+    kernel(m, n, alpha, beta, dev_C, dev_A, dev_B, dev_tmp);
+    BENCH_HIP_TRY(hipMemcpy(C.data(), dev_C, m * n * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+  state.free_dev_hip(dev_C);
+  state.free_dev_hip(dev_A);
+  state.free_dev_hip(dev_B);
+  state.free_dev_hip(dev_tmp);
+}

--- a/benchmarks/suites/polybench/syr2k/syr2k.hip
+++ b/benchmarks/suites/polybench/syr2k/syr2k.hip
@@ -1,0 +1,109 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+__global__ void kernel_beta(pbsize_t n, pbsize_t m,
+                            real alpha, real beta,
+                            real *C,
+                            real *A,
+                            real *B) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (i < n && j <= i)
+    C[i * n + j] *= beta;
+}
+
+__global__ void kernel_product(pbsize_t n, pbsize_t m,
+                               real alpha, real beta,
+                               real *C,
+                               real *A,
+                               real *B) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (i < n && j <= i) {
+    for (idx_t k = 0; k < m; k++)
+      C[i * n + j] += A[j * m + k] * alpha * B[i * m + k] + B[j * m + k] * alpha * A[i * m + k];
+  }
+}
+
+
+
+static void kernel(pbsize_t n, pbsize_t m,
+                   real alpha, real beta,
+                   real *C,
+                   real *A,
+                   real *B) {
+  const unsigned int threadsPerBlock = 256;
+
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(n, block.x), num_blocks(n, block.y), 1};
+    kernel_beta<<<block, grid>>>(n, m, alpha, beta, C, A, B);
+  }
+
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(n, block.x), num_blocks(n, block.y), 1};
+    kernel_product<<<block, grid>>>(n, m, alpha, beta, C, A, B);
+  }
+
+
+
+#if 0
+#pragma omp parallel default(none) firstprivate(n, m, alpha, beta, C, A, B)
+                       {
+#pragma omp for collapse(2) /* schedule(static) */ 
+                           for (idx_t i = 0; i < n; i++) 
+                               for (idx_t j = 0; j <= i; j++)
+                                   C[i][j] *= beta;
+
+#pragma omp for collapse(2) /* schedule(static) */ 
+                           for (idx_t i = 0; i < n; i++)
+                               for (idx_t j = 0; j <= i; j++)
+                                    for (idx_t k = 0; k < m; k++)                                  
+                                        C[i][j] += A[j][k] * alpha * B[i][k] + B[j][k] * alpha * A[i][k];
+
+
+                       }
+#endif
+}
+
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t n = pbsize;
+  pbsize_t m = pbsize - pbsize / 6;
+
+  real alpha = 1.5;
+  real beta = 1.2;
+  auto C = state.allocate_array<double>({n, n}, /*fakedata*/ true, /*verify*/ true, "C");
+  auto A = state.allocate_array<double>({n, m}, /*fakedata*/ true, /*verify*/ false, "A");
+  auto B = state.allocate_array<double>({n, m}, /*fakedata*/ true, /*verify*/ false, "B");
+
+  real *dev_C = state.allocate_dev_hip<real>(n * n);
+  real *dev_A = state.allocate_dev_hip<real>(n * m);
+  real *dev_B = state.allocate_dev_hip<real>(n * m);
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_C, C.data(), n * n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_A, A.data(), n * m * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_B, B.data(), n * m * sizeof(real), hipMemcpyHostToDevice));
+    kernel(n, m, alpha, beta, dev_C, dev_A, dev_B);
+    BENCH_HIP_TRY(hipMemcpy(C.data(), dev_C, n * n * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+  state.free_dev_hip(dev_C);
+  state.free_dev_hip(dev_A);
+  state.free_dev_hip(dev_B);
+}

--- a/benchmarks/suites/polybench/syrk/syrk.hip
+++ b/benchmarks/suites/polybench/syrk/syrk.hip
@@ -1,0 +1,105 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+__global__ void kernel_beta(pbsize_t n, pbsize_t m,
+                            real alpha, real beta,
+                            real *C,
+                            real *A) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (i < n && j <= i)
+    C[i * n + j] *= beta;
+}
+
+__global__ void kernel_product(pbsize_t n, pbsize_t m,
+                               real alpha, real beta,
+                               real *C,
+                               real *A) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (i < n && j <= i) {
+    for (idx_t k = 0; k < m; k++)
+      C[i * n + j] += alpha * A[i * m + k] * A[j * m + k];
+  }
+}
+
+
+
+static void kernel(pbsize_t n, pbsize_t m,
+                   real alpha, real beta,
+                   real *C,
+                   real *A) {
+  const unsigned int threadsPerBlock = 256;
+
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(n, block.x), num_blocks(n, block.y), 1};
+    kernel_beta<<<block, grid>>>(n, m, alpha, beta, C, A);
+  }
+
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(n, block.x), num_blocks(n, block.y), 1};
+    kernel_product<<<block, grid>>>(n, m, alpha, beta, C, A);
+  }
+
+
+
+#if 0
+#pragma omp parallel default(none) firstprivate(n, m, alpha, beta, C, A, B)
+        {
+#pragma omp for collapse(2) /* schedule(static) */ 
+            for (idx_t i = 0; i < n; i++)
+                for (idx_t j = 0; j <= i; j++)
+                    C[i*n+j] *= beta;
+
+#pragma omp for collapse(2) 
+            for (idx_t i = 0; i < n; i++)
+                for (idx_t j = 0; j <= i; j++)
+                    for (idx_t k = 0; k < m; k++)                                  
+                        C[i*n+j] += alpha * A[i*m+k] * A[j*m+k];
+
+
+        }
+#endif
+}
+
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t n = pbsize;
+  pbsize_t m = pbsize - pbsize / 6;
+
+  real alpha = 1.5;
+  real beta = 1.2;
+  auto C = state.allocate_array<real>({n, n}, /*fakedata*/ true, /*verify*/ true, "C");
+  auto A = state.allocate_array<real>({n, m}, /*fakedata*/ true, /*verify*/ false, "A");
+
+
+  real *dev_C = state.allocate_dev_hip<real>(n * n);
+  real *dev_A = state.allocate_dev_hip<real>(n * m);
+
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_C, C.data(), n * n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_A, A.data(), n * m * sizeof(real), hipMemcpyHostToDevice));
+    kernel(n, m, alpha, beta, dev_C, dev_A);
+    BENCH_HIP_TRY(hipMemcpy(C.data(), dev_C, n * n * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+  state.free_dev_hip(dev_C);
+  state.free_dev_hip(dev_A);
+}

--- a/benchmarks/suites/polybench/trisolv/trisolv.hip
+++ b/benchmarks/suites/polybench/trisolv/trisolv.hip
@@ -1,0 +1,97 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/for_each.h>
+#include <thrust/functional.h>
+#include <thrust/host_vector.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/reduce.h>
+#include <thrust/transform_reduce.h>
+
+
+
+struct Lij_times_xj : public thrust::unary_function<real, real> {
+  pbsize_t n;
+  thrust::device_ptr<real> L;
+  thrust::device_ptr<real> x;
+  idx_t i;
+
+  Lij_times_xj(pbsize_t n, thrust::device_ptr<real> L, thrust::device_ptr<real> x, idx_t i) : n(n), L(L), x(x), i(i) {}
+
+  __host__ __device__ real operator()(pbsize_t j) const {
+    real v = L[i * n + j] * x[j];
+    //  real v = L[i * n + j];
+
+    return v;
+  }
+};
+
+
+static void kernel(pbsize_t n, thrust::device_ptr<real> L, thrust::device_ptr<real> x, real b[], real *host_L) {
+#if 0
+    for (idx_t i = 0; i < n; i++) {
+        x[i] = b[i];
+        for (idx_t j = 0; j < i; j++)
+            x[i] -= L[i][j] * x[j];
+        x[i] /= L[i][i];
+    }
+#endif
+  //  fprintf(stderr, "Alive!\n");
+
+  for (idx_t i = 0; i < n; i++) {
+    Lij_times_xj op{n, L, x, i};
+    real sum = thrust::transform_reduce(
+        thrust::device,
+        thrust::make_counting_iterator(0),
+        thrust::make_counting_iterator(0) + i,
+        op,
+        (real)0,
+        thrust::plus<real>());
+    x[i] = (b[i] - sum) / L[i * n + i];
+    // fprintf(stderr, "sum = %f\n", sum);
+    // assert(L[0] == host_L[0]);
+    // x[i] = 1 +sum;
+  }
+
+#if 0
+  for (idx_t i = 0; i < n; i++) {
+    real sum = 0 ;
+#pragma omp parallel for schedule(static) default(none) firstprivate(i, x, L) reduction(+ \
+                                                                                        : sum)
+    for (idx_t j = 0; j < i; j++)
+      sum += L[i][j] * x[j];
+    x[i] =  (b[i] - sum) / L[i][i];
+  }
+#endif
+}
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t n = pbsize; // 2000
+
+
+  auto L = state.allocate_array<real>({n, n}, /*fakedata*/ true, /*verify*/ false, "L");
+  auto x = state.allocate_array<real>({n}, /*fakedata*/ false, /*verify*/ true, "x");
+  auto b = state.allocate_array<real>({n}, /*fakedata*/ true, /*verify*/ false, "b");
+
+  real *dev_L = state.allocate_dev_hip<real>(n * n);
+  real *dev_x = state.allocate_dev_hip<real>(n);
+  // real* dev_b = state.allocate_dev_hip<real>(n);
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_L, L.data(), n * n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_x, x.data(), n * sizeof(real), hipMemcpyHostToDevice));
+    // BENCH_HIP_TRY( hipMemcpy(dev_b, b.data(), n* sizeof(real), hipMemcpyHostToDevice));
+    kernel(n, thrust::device_pointer_cast(dev_L), thrust::device_pointer_cast(dev_x), b, &L.get()[0][0]);
+    BENCH_HIP_TRY(hipMemcpy(x.data(), dev_x, n * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+  state.free_dev_hip(dev_L);
+  state.free_dev_hip(dev_x);
+  // state.free_dev_hip(dev_b);
+}

--- a/benchmarks/suites/polybench/trmm/trmm.hip
+++ b/benchmarks/suites/polybench/trmm/trmm.hip
@@ -1,0 +1,97 @@
+// BUILD: add_benchmark(ppm=hip)
+
+#include <rosetta.h>
+
+
+static unsigned num_blocks(int num, int factor) {
+  return (num + factor - 1) / factor;
+}
+
+
+__global__ void kernel_contract(pbsize_t n, pbsize_t m,
+                                real alpha,
+                                real *B, real *A) {
+  idx_t j = blockDim.x * blockIdx.x + threadIdx.x;
+
+
+
+  if (j < n) {
+    for (idx_t i = 0; i < m; i++)
+      for (idx_t k = i + 1; k < m; k++)
+        B[i * n + j] += A[k * m + i] * B[k * n + j];
+  }
+}
+
+__global__ void kernel_alpha(pbsize_t n, pbsize_t m,
+                             real alpha,
+                             real *B, real *A) {
+  idx_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  idx_t j = blockDim.y * blockIdx.y + threadIdx.y;
+
+
+  if (i < m && j < n)
+    B[i * n + j] *= alpha;
+}
+
+
+static void kernel(pbsize_t n, pbsize_t m,
+                   real alpha,
+                   real *B, real *A) {
+  const unsigned int threadsPerBlock = 256;
+
+
+  kernel_contract<<<threadsPerBlock, num_blocks(n, threadsPerBlock)>>>(n, m, alpha, B, A);
+
+
+  {
+    dim3 block{threadsPerBlock / 32, 32, 1};
+    dim3 grid{num_blocks(m, block.x), num_blocks(n, block.y), 1};
+    kernel_alpha<<<block, grid>>>(n, m, alpha, B, A);
+  }
+
+
+
+#if 0
+#pragma omp parallel default(none) firstprivate(n, m, alpha, B, A)
+                       {
+#pragma omp for 
+                           for (idx_t j = 0; j < n; j++) 
+                                for (idx_t i = 0; i < m; i++)                             
+                                   for (idx_t k = i + 1; k < m; k++)
+                                       B[i][j] += A[k][i] * B[k][j];
+
+#pragma omp for collapse(2) schedule(static)
+                                   for (idx_t i = 0; i < m; i++)
+                                       for (idx_t j = 0; j < n; j++)
+                                   B[i][j] *= alpha;
+                               
+                       }
+#endif
+}
+
+
+
+void run(State &state, pbsize_t pbsize) {
+  pbsize_t n = pbsize;
+  pbsize_t m = pbsize - pbsize / 6;
+
+  real alpha = 1.5;
+  auto B = state.allocate_array<real>({m, n}, /*fakedata*/ true, /*verify*/ true, "B");
+  auto A = state.allocate_array<real>({n, m}, /*fakedata*/ true, /*verify*/ false, "A");
+
+  real *dev_B = state.allocate_dev_hip<real>(m * n);
+  real *dev_A = state.allocate_dev_hip<real>(n * m);
+
+  for (auto &&_ : state) {
+    BENCH_HIP_TRY(hipMemcpy(dev_B, B.data(), m * n * sizeof(real), hipMemcpyHostToDevice));
+    BENCH_HIP_TRY(hipMemcpy(dev_A, A.data(), n * m * sizeof(real), hipMemcpyHostToDevice));
+    kernel(n, m, alpha, dev_B, dev_A);
+    BENCH_HIP_TRY(hipMemcpy(B.data(), dev_B, m * n * sizeof(real), hipMemcpyDeviceToHost));
+
+    BENCH_HIP_TRY(hipDeviceSynchronize());
+  }
+
+
+  state.free_dev_hip(dev_B);
+  state.free_dev_hip(dev_A);
+}


### PR DESCRIPTION
Includes HIP Polybench benchmarks  except 3mm, durbin, and gramschmidt.
Passed the verification with  `--verify`. Excluded `3mm`, `durbin`, and `gramschmidt` from the PR as they are failing verification. 
JLSE `--bench` results on `gpu_amd_mi100`:
```
python rosetta.py --bench --filter-include-program-substr polybench --filter-include-ppm-exact hip --cmake-def=ROSETTA_PPM_OPENMP_TARGET=OFF
```
```
           Benchmark            # Samples       Wall             User             Kernel        Max RSS  Peak Allocation
------------------------------- --------- ---------------- ---------------- ------------------ --------- ---------------
suites.polybench.2mm            26961     353.35µs (±0.3%) 352.96µs (±0.3%) 362.93ns (±36.5%)  228.46MiB 1.00MiB        
suites.polybench.adi            233        41.57ms (±0.3%)  41.57ms (±0.3%)   1.22µs (±136.4%) 220.78MiB 312.50KiB      
suites.polybench.atax           24664     390.21µs (±0.3%) 331.73µs (±0.6%)  58.34µs (±3.0%)   225.05MiB 1.16MiB        
suites.polybench.bicg           48191     193.20µs (±0.3%) 192.08µs (±0.3%)   1.13µs (±11.7%)  240.15MiB 135.16KiB      
suites.polybench.cholesky       7157        1.32ms (±0.3%)   1.32ms (±0.3%)   3.07ns (±80.7%)  220.83MiB 312.50KiB      
suites.polybench.correlation    21332     439.93µs (±0.4%) 439.32µs (±0.3%) 589.35ns (±35.6%)  226.68MiB 812.05KiB      
suites.polybench.covariance     22356     421.96µs (±0.3%) 421.21µs (±0.3%) 742.53ns (±30.0%)  226.76MiB 871.03KiB      
suites.polybench.deriche        13944     678.09µs (±0.3%) 677.47µs (±0.3%) 577.52ns (±54.3%)  224.02MiB 1.85MiB        
suites.polybench.doitgen        10586     896.02µs (±0.3%) 739.89µs (±0.8%) 101.92µs (±5.0%)   223.18MiB 1.41MiB        
suites.polybench.fdtd-2d        6896        1.40ms (±0.3%)   1.40ms (±0.3%)   0.00ns           221.62MiB 1.10MiB        
suites.polybench.floyd-warshall 3390        2.87ms (±0.3%)   2.52ms (±1.2%) 347.04µs (±8.0%)   222.38MiB 1.91MiB        
suites.polybench.gemm           33739     282.33µs (±0.3%) 280.36µs (±0.3%)   1.96µs (±12.6%)  235.12MiB 1.00MiB        
suites.polybench.gemver         16886     556.94µs (±0.6%) 440.29µs (±1.0%)  96.22µs (±3.2%)   223.89MiB 1.25MiB        
suites.polybench.gesummv        18722     496.91µs (±0.4%) 399.56µs (±0.8%)  97.21µs (±2.9%)   225.27MiB 2.45MiB        
suites.polybench.heat-3d        4629        2.10ms (±0.3%)   2.10ms (±0.3%) 886.37ns (±131.6%) 221.49MiB 1000.00KiB     
suites.polybench.jacobi-1d      218205     33.72µs (±0.4%)  33.41µs (±0.4%) 327.18ns (±4.3%)   309.20MiB 6.25KiB        
suites.polybench.jacobi-2d      77606     115.16µs (±0.4%) 114.21µs (±0.3%) 975.54ns (±10.7%)  253.34MiB 976.56KiB      
suites.polybench.lu             3568        2.67ms (±0.3%)   2.36ms (±1.1%) 308.62µs (±8.1%)   221.63MiB 1.22MiB        
suites.polybench.ludcmp         1           5.9s             5.9s             7.22ms           220.50MiB 315.62KiB      
suites.polybench.mvt            21144     444.84µs (±0.3%) 348.45µs (±0.8%)  96.20µs (±2.6%)   227.28MiB 1.23MiB        
suites.polybench.nussinov       4240        2.30ms (±0.3%)   2.29ms (±0.3%)   2.65µs (±81.7%)  220.55MiB 113.44KiB      
suites.polybench.seidel-2d      30475     313.65µs (±0.3%) 134.19µs (±1.4%) 179.12µs (±1.0%)   234.03MiB 1.22MiB        
suites.polybench.symm           23621     394.29µs (±0.3%) 393.15µs (±0.3%)   1.11µs (±23.8%)  227.67MiB 1.11MiB        
suites.polybench.syr2k          24156     387.96µs (±0.3%) 387.28µs (±0.3%) 656.81ns (±30.0%)  227.63MiB 1.17MiB        
suites.polybench.syrk           33632     283.71µs (±0.3%) 276.08µs (±0.3%)   1.98µs (±12.4%)  234.83MiB 825.00KiB      
suites.polybench.trisolv        576        16.93ms (±0.3%)  16.55ms (±0.6%) 375.16µs (±24.8%)  221.71MiB 1.23MiB        
suites.polybench.trmm           1709        5.71ms (±0.3%)   5.71ms (±0.3%)   2.05µs (±195.6%) 221.32MiB 750.00KiB  
```